### PR TITLE
Adding resolving from shared + fallback for assembly loading

### DIFF
--- a/Source/Assemblies/AssemblyContext.cs
+++ b/Source/Assemblies/AssemblyContext.cs
@@ -154,23 +154,11 @@ namespace Dolittle.Assemblies
                 return string.Equals(runtime.Name, name.Name, StringComparison.OrdinalIgnoreCase);
             }
 
+            var compilationLibrary = DependencyContext.CompileLibraries.FirstOrDefault(NamesMatch);
+            if( compilationLibrary != null ) return compilationLibrary;
+
             var runtimeLibrary = DependencyContext.RuntimeLibraries.FirstOrDefault(NamesMatch);
-            if (runtimeLibrary != null)
-                return GetCompilationLibraryFrom(runtimeLibrary);
-
-            var version = name.Version??new Version(1,0,0,0);
-
-            return new CompilationLibrary(
-                "package",
-                name.Name,
-                $"{version.Major}.{version.Minor}.{version.Revision}",
-                string.Empty,
-                new string[0],
-                new Dependency[0],
-                false,
-                string.Empty,
-                string.Empty
-            );
+            return GetCompilationLibraryFrom(runtimeLibrary);
         }
 
 

--- a/Source/Assemblies/AssemblyContext.cs
+++ b/Source/Assemblies/AssemblyContext.cs
@@ -27,7 +27,7 @@ namespace Dolittle.Assemblies
         public AssemblyContext(Assembly assembly)
         {
             Assembly = assembly;
-
+            
             AssemblyLoadContext.Default.Resolving += OnResolving;
 
             DependencyContext = DependencyContext.Load(assembly);
@@ -136,7 +136,12 @@ namespace Dolittle.Assemblies
             {
                 try
                 {
-                    return AssemblyLoadContext.LoadFromAssemblyPath(assemblies[0]);
+                    var assembly = assemblies[0];
+                    var segments = assembly.Split(Path.DirectorySeparatorChar);
+                    var hasRef = segments.Any(_ => _.ToLowerInvariant() == "ref");
+                    if( hasRef ) assembly = assembly.Replace($"ref{Path.DirectorySeparatorChar}",$"lib{Path.DirectorySeparatorChar}");
+
+                    return AssemblyLoadContext.LoadFromAssemblyPath(assembly);
                 } 
                 catch
                 {
@@ -154,11 +159,11 @@ namespace Dolittle.Assemblies
                 return string.Equals(runtime.Name, name.Name, StringComparison.OrdinalIgnoreCase);
             }
 
-            var compilationLibrary = DependencyContext.CompileLibraries.FirstOrDefault(NamesMatch);
-            if( compilationLibrary != null ) return compilationLibrary;
-
             var runtimeLibrary = DependencyContext.RuntimeLibraries.FirstOrDefault(NamesMatch);
-            return GetCompilationLibraryFrom(runtimeLibrary);
+            if( runtimeLibrary != null ) return GetCompilationLibraryFrom(runtimeLibrary);
+
+            var compilationLibrary = DependencyContext.CompileLibraries.FirstOrDefault(NamesMatch);
+            return compilationLibrary;
         }
 
 

--- a/Source/Assemblies/CompositeAssemblyResolver.cs
+++ b/Source/Assemblies/CompositeAssemblyResolver.cs
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Dolittle. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyModel;
+using Microsoft.Extensions.DependencyModel.Resolution;
+
+namespace Dolittle.Assemblies
+{
+    /// <summary>
+    /// Represents a <see cref="ICompilationAssemblyResolver"/> that can run through multiple resolvers
+    /// </summary>
+    public class CompositeAssemblyResolver : ICompilationAssemblyResolver
+    {
+        readonly ICompilationAssemblyResolver[] _resolvers;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="CompositeAssemblyResolver"/>
+        /// </summary>
+        /// <param name="resolvers">Params of <see cref="ICompilationAssemblyResolver">resolvers</see></param>
+        public CompositeAssemblyResolver(params ICompilationAssemblyResolver[] resolvers)
+        {
+            _resolvers = resolvers;
+        }
+
+        /// <inheritdoc/>
+        public bool TryResolveAssemblyPaths(CompilationLibrary library, List<string> assemblies)
+        {
+            var found = false;
+
+            foreach( var resolver in _resolvers )
+            {
+                try
+                {
+                    found |= resolver.TryResolveAssemblyPaths(library, assemblies);
+                } catch { }
+            }
+            
+            return found;
+        }
+    }
+}

--- a/Source/Assemblies/CompositeAssemblyResolver.cs
+++ b/Source/Assemblies/CompositeAssemblyResolver.cs
@@ -34,6 +34,7 @@ namespace Dolittle.Assemblies
                 try
                 {
                     found |= resolver.TryResolveAssemblyPaths(library, assemblies);
+                    if( assemblies.Count > 0 ) break;
                 } catch { }
             }
             

--- a/Source/Assemblies/PackageRuntimeShareAssemblyResolver.cs
+++ b/Source/Assemblies/PackageRuntimeShareAssemblyResolver.cs
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Dolittle. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.DependencyModel;
+using Microsoft.Extensions.DependencyModel.Resolution;
+
+namespace Dolittle.Assemblies
+{
+    /// <summary>
+    /// Represents a <see cref="ICompilationAssemblyResolver"/> that tries to resolve from the package runtime shared store
+    /// <remarks>
+    /// Read more here https://natemcmaster.com/blog/2018/08/29/netcore-primitives-2/
+    /// https://github.com/dotnet/corefx/issues/11639
+    /// </remarks>
+    /// </summary>
+    public class PackageRuntimeShareAssemblyResolver : ICompilationAssemblyResolver
+    {
+        /// <inheritdoc/>
+        public bool TryResolveAssemblyPaths(CompilationLibrary library, List<string> assemblies)
+        {
+            var basePath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+                @"c:\Program Files\dotnet\shared" :
+                "/usr/local/share/dotnet/shared";
+
+            var found = false;
+
+            foreach (var path in Directory.GetDirectories(basePath))
+            {
+                if (found) break;
+                var versionDir = Path.Combine(path, library.Version);
+                if (Directory.Exists(versionDir))
+                {
+                    foreach (var file in Directory.GetFiles(versionDir))
+                    {
+                        if (found) break;
+                        if (Path.GetFileName(file).ToLower().Equals(library.Name.ToLower() + ".dll"))
+                        {
+                            assemblies.Add(file);
+                            found = true;
+                        }
+                    }
+                }
+            }
+
+            return found;
+        }
+    }
+}


### PR DESCRIPTION
Should fix this: https://github.com/dolittle-runtime/DotNET.SDK/issues/221

I've tested with the following scenarios:

- Regular build
- WebAssembly build
- WebAssemblty runtime
- ASP.NET Core Runtime context (w/ Controller and ControllerBase controllers)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1115616103797671/1130011566732786)
