### PR TITLE
added aliases for new "wrong" Urls

### DIFF
--- a/Documentation/Configuration/_index.md
+++ b/Documentation/Configuration/_index.md
@@ -3,4 +3,6 @@ title: Configuration
 description: Overview of the Configuration System
 keywords: Overview, Configuration
 author: einari
+aliases: 
+    - /fundamentals/dotnet.fundamentals/configuration
 ---

--- a/Documentation/DependencyInversion/_index.md
+++ b/Documentation/DependencyInversion/_index.md
@@ -3,6 +3,8 @@ title: DependencyInversion
 description: Overview of Dependency Inversion
 keywords: Overview, Dependency Inversion
 author: einari
+aliases: 
+    - /fundamentals/dotnet.fundamentals/dependencyinversion
 ---
 In our fundamentals, you'll find a package called [DependencyInversion](https://www.nuget.org/packages/Dolittle.DependencyInversion/).
 [Dependency inversion](https://en.wikipedia.org/wiki/Dependency_inversion_principle) is the last principle

--- a/Documentation/DependencyInversion/container.md
+++ b/Documentation/DependencyInversion/container.md
@@ -4,6 +4,8 @@ description: Overview of how you can work with the container
 keywords: Overview, Dependency Inversion
 author: einari
 weight: 2
+aliases: 
+    - /fundamentals/dotnet.fundamentals/dependencyinversion/container
 ---
 At the core of the `DependencyInversion` system sits `IContainer`.
 This is something we build at startup and is considered immutable.

--- a/Documentation/DependencyInversion/conventions.md
+++ b/Documentation/DependencyInversion/conventions.md
@@ -4,6 +4,8 @@ description: Overview of how conventions work
 keywords: Conventions, Dependency Inversion
 author: einari
 weight: 4
+aliases: 
+    - /fundamentals/dotnet.fundamentals/dependencyinversion/conventions
 ---
 Important part of how we think at Dolittle, is by enabling conventions.
 Instead of having to configure everything explicitly, often at times there

--- a/Documentation/DependencyInversion/factory_for.md
+++ b/Documentation/DependencyInversion/factory_for.md
@@ -4,6 +4,8 @@ description: Overview of how to work with the factory for
 keywords: Factory, Creation, Dependency Inversion
 author: einari
 weight: 7
+aliases: 
+    - /fundamentals/dotnet.fundamentals/dependencyinversion/factory_for
 ---
 Instead of working with the container as a service locator directly,
 as described [here]({{< relref container >}}); you can represent what

--- a/Documentation/DependencyInversion/getting_started.md
+++ b/Documentation/DependencyInversion/getting_started.md
@@ -4,6 +4,8 @@ description: Overview of how you can started
 keywords: Getting started, Dependency Inversion
 author: einari
 weight: 1
+aliases: 
+    - /fundamentals/dotnet.fundamentals/dependencyinversion/getting_started
 ---
 The simplest thing for getting started is to use the built-in booting system
 which will take care of setting everything up in order.

--- a/Documentation/DependencyInversion/lifecycle.md
+++ b/Documentation/DependencyInversion/lifecycle.md
@@ -4,6 +4,8 @@ description: Overview of how to work with lifecycle
 keywords: Lifecycle, Dependency Inversion
 author: einari
 weight: 6
+aliases: 
+    - /fundamentals/dotnet.fundamentals/dependencyinversion/lifecycle
 ---
 One of the traits of an IoC container is to govern the lifecycle outside of
 the types needing the dependencies. This can typically be done at the

--- a/Documentation/DependencyInversion/providing_bindings.md
+++ b/Documentation/DependencyInversion/providing_bindings.md
@@ -4,6 +4,8 @@ description: Overview of how you can provide bindings
 keywords: Overview, Dependency Inversion
 author: einari
 weight: 3
+aliases: 
+    - /fundamentals/dotnet.fundamentals/dependencyinversion/providing_bindings/
 ---
 When a [convention]({{< relref conventions >}}) does not cover your
 scenario, or you need to bind something based on configuration or similar.

--- a/Documentation/PropertyBags/_index.md
+++ b/Documentation/PropertyBags/_index.md
@@ -3,6 +3,8 @@ title: Property Bags and Object Factory
 description: Overview of Property Bag
 keywords: Overview, Property Bag
 author: smithmx
+aliases: 
+    - /fundamentals/dotnet.fundamentals/propertybags
 ---
 ## Definition
 

--- a/Documentation/Resilience/_index.md
+++ b/Documentation/Resilience/_index.md
@@ -3,6 +3,8 @@ title: Resilience
 description: Overview of Resilience
 keywords: Overview, Resilience
 author: einari
+aliases: 
+    - /fundamentals/dotnet.fundamentals/resilience
 ---
 In our fundamentals, you'll find a package called [Resilience](https://www.nuget.org/packages/Dolittle.Resilience/).
 The purpose of this package is to make it possible to define policies that are to be used for

--- a/Documentation/Resilience/default_policy.md
+++ b/Documentation/Resilience/default_policy.md
@@ -4,6 +4,8 @@ description: Overview of how to work with a default policy
 keywords: Overview, Resilience
 author: einari
 weight: 1
+aliases: 
+    - /fundamentals/dotnet.fundamentals/resilience/default_policy
 ---
 The resilience system has the concept of a default policy.
 This is the policy that gets used if there is no specific policy for a

--- a/Documentation/Resilience/named_policy.md
+++ b/Documentation/Resilience/named_policy.md
@@ -4,6 +4,8 @@ description: Overview of how to work with a named policy
 keywords: Overview, Resilience
 author: einari
 weight: 2
+aliases: 
+    - /fundamentals/dotnet.fundamentals/resilience/named_policy
 ---
 Named policies can be very useful is you want to have a policy that is used
 by multiple different parts of your system and accessible by a well-known

--- a/Documentation/Resilience/policy_for_type.md
+++ b/Documentation/Resilience/policy_for_type.md
@@ -4,6 +4,8 @@ description: Overview of how to work with a policy for a type
 keywords: Overview, Resilience
 author: einari
 weight: 3
+aliases: 
+    - /fundamentals/dotnet.fundamentals/resilience/policy_for_type
 ---
 Policies for specific types are accessible and defined linked to a type. These can
 be very useful to use for specific resources needing resilience and makes it easy

--- a/Documentation/Services/_index.md
+++ b/Documentation/Services/_index.md
@@ -3,6 +3,8 @@ title: Services
 description: Overview of services
 keywords: Overview, Services
 author: einari
+aliases: 
+    - /fundamentals/dotnet.fundamentals/services
 ---
 In our fundamentals, you'll find a package called [Services](https://www.nuget.org/packages/Dolittle.Services/).
 The purpose of this package is to make it possible to provide hosted services that leverages

--- a/Documentation/Services/binding_services.md
+++ b/Documentation/Services/binding_services.md
@@ -4,6 +4,8 @@ description: How to bind your gRPC for a service type
 keywords: Overview, gRPC
 author: einari
 weight: 1
+aliases: 
+    - /fundamentals/dotnet.fundamentals/services/binding_services
 ---
 gRPC services are typically defined in a `.proto` file and using the gRPC tooling you can
 generate a proxy representation for your programming language. These are then types that

--- a/Documentation/Services/exposing_service_type.md
+++ b/Documentation/Services/exposing_service_type.md
@@ -4,6 +4,8 @@ description: How to expose a service type
 keywords: Overview, gRPC
 author: einari
 weight: 1
+aliases: 
+    - /fundamentals/dotnet.fundamentals/services/exposing_service_type
 ---
 A **service type** is the definition of an entrypoint that expose multiple services on it.
 You can think of it as the thing that is exposing a TCP socket on a specific port.

--- a/Documentation/_index.md
+++ b/Documentation/_index.md
@@ -2,4 +2,6 @@
 title: .NET Fundamentals
 description: .NET Fundamentals
 repository: https://github.com/dolittle-fundamentals/DotNET.Fundamentals
+aliases: 
+    - /fundamentals/dotnet.fundamentals/
 ---


### PR DESCRIPTION
This is then to make sure if someone has stored or linked to these pages, will still work, and to let Google and other bots know that these pages has moved

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1115616103797671/1144708871239255)
