### PR TITLE
Add dotnet path for Ubuntu 19.04 for AssemblyResolvers

### DIFF
--- a/Source/Assemblies/NuGetFallbackFolderAssemblyResolver.cs
+++ b/Source/Assemblies/NuGetFallbackFolderAssemblyResolver.cs
@@ -22,9 +22,21 @@ namespace Dolittle.Assemblies
         /// <inheritdoc/>
         public bool TryResolveAssemblyPaths(CompilationLibrary library, List<string> assemblies)
         {
-            var basePath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)?
-                            @"c:\Program Files\dotnet\sdk\NuGetFallbackFolder":
-                            "/usr/local/share/dotnet/sdk/NuGetFallbackFolder";
+            string basePath;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                basePath = @"c:\Program Files\dotnet\sdk\NuGetFallbackFolder";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                // default location on Ubuntu 19.04
+                basePath = "/usr/share/dotnet/sdk/NuGetFallbackFolder";
+            }
+            else 
+            {
+                // keep the OSX location as the default
+                basePath = "/usr/local/share/dotnet/sdk/NuGetFallbackFolder";
+            }
 
             if (!Directory.Exists(basePath)) return false;
             

--- a/Source/Assemblies/NuGetFallbackFolderAssemblyResolver.cs
+++ b/Source/Assemblies/NuGetFallbackFolderAssemblyResolver.cs
@@ -14,8 +14,9 @@ namespace Dolittle.Assemblies
     /// 
     /// </summary>
     /// <remarks>
-    /// Linux / macOS : /usr/local/share/dotnet/sdk/NuGetFallbackFolder/{package path}
-    /// Windows       : C:/Program Files/dotnet/sdk/NuGetFallbackFolder/{package path} 
+    /// macOS : /usr/local/share/dotnet/sdk/NuGetFallbackFolder/{package path}
+    /// Linux : /usr/share/dotnet/sdk/NuGetFallbackFolder/{package path}
+    /// Windows : C:/Program Files/dotnet/sdk/NuGetFallbackFolder/{package path} 
     /// </remarks>
     public class NuGetFallbackFolderAssemblyResolver : ICompilationAssemblyResolver
     {

--- a/Source/Assemblies/PackageRuntimeShareAssemblyResolver.cs
+++ b/Source/Assemblies/PackageRuntimeShareAssemblyResolver.cs
@@ -22,9 +22,21 @@ namespace Dolittle.Assemblies
         /// <inheritdoc/>
         public bool TryResolveAssemblyPaths(CompilationLibrary library, List<string> assemblies)
         {
-            var basePath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
-                @"c:\Program Files\dotnet\shared" :
-                "/usr/local/share/dotnet/shared";
+            string basePath;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                basePath = @"c:\Program Files\dotnet\shared";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                // default location on Ubuntu 19.04
+                basePath = "/usr/share/dotnet/shared";
+            }
+            else 
+            {
+                // keep the OSX location as the default
+                basePath = "/usr/local/share/dotnet/shared";
+            }
 
             var found = false;
 

--- a/Source/Assemblies/PackageRuntimeStoreAssemblyResolver.cs
+++ b/Source/Assemblies/PackageRuntimeStoreAssemblyResolver.cs
@@ -23,9 +23,21 @@ namespace Dolittle.Assemblies
         /// <inheritdoc/>
         public bool TryResolveAssemblyPaths(CompilationLibrary library, List<string> assemblies)
         {
-            var basePath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)?
-                            @"c:\Program Files\dotnet\store":
-                            "/usr/local/share/dotnet/store";
+            string basePath;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                basePath = @"c:\Program Files\dotnet\store";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                // couldn't find this on Ubuntu 19.04, fresh dotnet sdk2.2 install
+                basePath = "/usr/share/dotnet/store";
+            }
+            else 
+            {
+                // keep the OSX location as the default
+                basePath = "/usr/local/share/dotnet/store";
+            }
 
             var cpuBasePath = Path.Combine(basePath,RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant());
             if (!Directory.Exists(cpuBasePath)) return false;

--- a/Source/Assemblies/PackageRuntimeStoreAssemblyResolver.cs
+++ b/Source/Assemblies/PackageRuntimeStoreAssemblyResolver.cs
@@ -15,8 +15,9 @@ namespace Dolittle.Assemblies
     /// </summary>
     /// <remarks>
     /// Read more here : https://docs.microsoft.com/en-us/dotnet/core/deploying/runtime-store
-    /// Linux / macOS : /usr/local/share/dotnet/store/{CPU}/{targetFramework e.g. netcoreapp2.0}/{package path}
-    /// Windows       : C:/Program Files/dotnet/store/{CPU}/{targetFramework e.g. netcoreapp2.0}/{package path} 
+    /// macOS : /usr/local/share/dotnet/store/{CPU}/{targetFramework e.g. netcoreapp2.0}/{package path}
+    /// Linux : /usr/share/dotnet/store/{CPU}/{targetFramework e.g. netcoreapp2.0}/{package path}
+    /// Windows : C:/Program Files/dotnet/store/{CPU}/{targetFramework e.g. netcoreapp2.0}/{package path} 
     /// </remarks>
     public class PackageRuntimeStoreAssemblyResolver : ICompilationAssemblyResolver
     {
@@ -30,7 +31,7 @@ namespace Dolittle.Assemblies
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                // couldn't find this on Ubuntu 19.04, fresh dotnet sdk2.2 install
+                // couldn't find this on Ubuntu 19.04 on a fresh dotnet sdk2.2 install
                 basePath = "/usr/share/dotnet/store";
             }
             else 


### PR DESCRIPTION
Tested on Ubuntu 19.04 on a dolittle project.

Fixes issues https://github.com/dolittle-fundamentals/DotNET.Fundamentals/issues/258  and https://github.com/dolittle-fundamentals/DotNET.Fundamentals/issues/244, not the prettiest fix and in the future we probably could do with letting the user specify the path or having a more robust/general dotnet path discovery function/tool.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1115616103797671/1146246334480284)
