### PR TITLE
Adding library inclusion

### DIFF
--- a/Samples/Booting/Booting.csproj
+++ b/Samples/Booting/Booting.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <NoWarn>$(NoWarn);CS0618</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Dolittle.Common" Version="2.5.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Source\Booting\Booting.csproj" />
+    <ProjectReference Include="..\..\Source\Collections\Collections.csproj" />
+    <ProjectReference Include="..\..\Source\Configuration\Configuration.csproj" />
+    <ProjectReference Include="..\..\Source\DependencyInversion.Booting\DependencyInversion.Booting.csproj" />
+    <ProjectReference Include="..\..\Source\DependencyInversion.Autofac\DependencyInversion.Autofac.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Samples/Booting/Program.cs
+++ b/Samples/Booting/Program.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Booting;
+using Dolittle.Collections;
+using Microsoft.Extensions.Logging;
+using ILogger = Dolittle.Logging.ILogger;
+
+namespace Booting
+{
+    static class Program
+    {
+        static void Main()
+        {
+            var loggerFactory = new LoggerFactory();
+            loggerFactory.AddConsole();
+
+            var bootloader = Bootloader.Configure(_ => _
+                .UseLoggerFactory(loggerFactory)
+                .Development()
+                .IncludeAssembliesStartingWith("Microsoft"));
+
+            var result = bootloader.Start();
+            var logger = result.Container.Get<ILogger>();
+            result.Assemblies.GetAll().ForEach(_ => logger.Information($"Assembly '{_}' loaded and part of discovery"));
+
+            loggerFactory.Dispose();
+        }
+    }
+}

--- a/Source/Assemblies/Bootstrap/Boot.cs
+++ b/Source/Assemblies/Bootstrap/Boot.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Reflection;
 using Dolittle.Assemblies.Configuration;
 using Dolittle.Assemblies.Rules;
@@ -19,14 +20,21 @@ namespace Dolittle.Assemblies.Bootstrap
         /// <param name="logger"><see cref="ILogger"/> to use for logging.</param>
         /// <param name="entryAssembly"><see cref="Assembly"/> to use as entry assembly - null indicates it will get it from the <see cref="Assembly.GetEntryAssembly()"/> method.</param>
         /// <param name="defaultAssemblyProvider">The default <see cref="ICanProvideAssemblies"/> - null inidicates it will use the default implementation.</param>
+        /// <param name="excludeAllCallback">A callback to build on the exclude all specification.</param>
         /// <returns>Discovered <see cref="IAssemblies"/>.</returns>
-        public static IAssemblies Start(ILogger logger, Assembly entryAssembly = null, ICanProvideAssemblies defaultAssemblyProvider = null)
+        public static IAssemblies Start(
+            ILogger logger,
+            Assembly entryAssembly = null,
+            ICanProvideAssemblies defaultAssemblyProvider = null,
+            Action<ExcludeAll> excludeAllCallback = null)
         {
             var assembliesConfigurationBuilder = new AssembliesConfigurationBuilder();
-            assembliesConfigurationBuilder
+            var assembliesSpecification = assembliesConfigurationBuilder
                 .ExcludeAll()
                 .ExceptProjectLibraries()
                 .ExceptDolittleLibraries();
+
+            excludeAllCallback?.Invoke(assembliesSpecification);
 
             if (entryAssembly == null)
             {

--- a/Source/Assemblies/Rules/ExcludeAllExtensions.cs
+++ b/Source/Assemblies/Rules/ExcludeAllExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Dolittle.Collections;
 using Dolittle.Specifications;
 
 namespace Dolittle.Assemblies.Rules
@@ -34,6 +35,20 @@ namespace Dolittle.Assemblies.Rules
         {
             var specification = excludeAll.Specification;
             specification = specification.Or(new NameStartsWith("Dolittle"));
+            excludeAll.Specification = specification;
+            return excludeAll;
+        }
+
+        /// <summary>
+        /// Include specific assemblies that start with a specific name.
+        /// </summary>
+        /// <param name="excludeAll"><see cref="ExcludeAll">configuration object</see>.</param>
+        /// <param name="names">Params of names to include.</param>
+        /// <returns>Chain of <see cref="ExcludeAll">configuration object</see>.</returns>
+        public static ExcludeAll ExceptAssembliesStartingWith(this ExcludeAll excludeAll, params string[] names)
+        {
+            var specification = excludeAll.Specification;
+            names.ForEach(_ => specification = specification.Or(new NameStartsWith(_)));
             excludeAll.Specification = specification;
             return excludeAll;
         }

--- a/Source/Booting/Stages/04-Discovery/DiscoveryBootBuilderExtensions.cs
+++ b/Source/Booting/Stages/04-Discovery/DiscoveryBootBuilderExtensions.cs
@@ -36,5 +36,17 @@ namespace Dolittle.Booting
             bootBuilder.Set<DiscoverySettings>(_ => _.AssemblyProvider, assemblyProvider);
             return bootBuilder;
         }
+
+        /// <summary>
+        /// Include assemblies that start with a certain name in the discovery.
+        /// </summary>
+        /// <param name="bootBuilder"><see cref="BootBuilder"/> to build.</param>
+        /// <param name="names">Params of names to include.</param>
+        /// <returns>Chained <see cref="BootBuilder"/>.</returns>
+        public static IBootBuilder IncludeAssembliesStartingWith(this IBootBuilder bootBuilder, params string[] names)
+        {
+            bootBuilder.Set<DiscoverySettings>(_ => _.IncludeAssembliesStartWith, names);
+            return bootBuilder;
+        }
     }
 }

--- a/Source/Booting/Stages/04-Discovery/DiscoverySettings.cs
+++ b/Source/Booting/Stages/04-Discovery/DiscoverySettings.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using Dolittle.Assemblies;
 
 namespace Dolittle.Booting.Stages
@@ -10,6 +11,11 @@ namespace Dolittle.Booting.Stages
     /// </summary>
     public class DiscoverySettings : IRepresentSettingsForBootStage
     {
+        /// <summary>
+        /// Gets the collection of assembly names that can be included in discovery, based on starting with name.
+        /// </summary>
+        public IEnumerable<string> IncludeAssembliesStartWith { get; internal set; }
+
         /// <summary>
         /// Gets the <see cref="ICanProvideAssemblies">assembly provider</see> to use.
         /// </summary>


### PR DESCRIPTION
This adds the ability to specify additional libraries to include in the discovery phase. 
By default we have an ExcludeAll() rule and this provides a way to extend with assemblies to include based on the start of the name.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1115616103797671/1156553025830269)
