### PR TITLE
Adding a way to easily add additional arguments on calls

### DIFF
--- a/Source/Protobuf/Extensions.cs
+++ b/Source/Protobuf/Extensions.cs
@@ -3,9 +3,11 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Dolittle.Concepts;
 using Dolittle.Security;
 using Google.Protobuf;
+using Grpc.Core;
 
 namespace Dolittle.Protobuf
 {
@@ -14,6 +16,8 @@ namespace Dolittle.Protobuf
     /// </summary>
     public static class Extensions
     {
+        static string _argumentsKey = $"arguments{Metadata.BinaryHeaderSuffix}";
+
         /// <summary>
         /// Convert a <see cref="ByteString"/> to a <see cref="ConceptAs{T}"/> of type <see cref="System.Guid"/>.
         /// </summary>
@@ -97,6 +101,42 @@ namespace Dolittle.Protobuf
         public static Claims ToClaims(this IEnumerable<Security.Contracts.Claim> claims)
         {
             return new Claims(claims.Select(_ => new Claim(_.Key, _.Value, _.ValueType)));
+        }
+
+        /// <summary>
+        /// Convert to metadata that is used as arguments in the header.
+        /// </summary>
+        /// <param name="message"><see cref="IMessage"/> to convert.</param>
+        /// <returns>A <see cref="Metadata.Entry"/> that can be used directly.</returns>
+        public static Metadata.Entry ToArgumentsMetadata(this IMessage message)
+        {
+            return new Metadata.Entry(_argumentsKey, message.ToByteArray());
+        }
+
+        /// <summary>
+        /// Get the arguments message from a <see cref="ServerCallContext"/>.
+        /// </summary>
+        /// <typeparam name="TMessage">The type of <see cref="IMessage"/>.</typeparam>
+        /// <param name="callContext"><see cref="ServerCallContext"/> to get arguments message from.</param>
+        /// <exceptions><see cref="MissingArgumentsHeaderOnCallContext"/>.</exceptions>
+        /// <returns>The arguments message instance.</returns>
+        public static TMessage GetArgumentsMessage<TMessage>(this ServerCallContext callContext)
+            where TMessage : IMessage<TMessage>, new()
+        {
+            var entry = callContext.RequestHeaders.FirstOrDefault(_ => _.Key == _argumentsKey);
+            if (entry == default)
+            {
+                throw new MissingArgumentsHeaderOnCallContext(callContext);
+            }
+
+            var property = typeof(TMessage).GetProperty("Parser", BindingFlags.Public | BindingFlags.Static);
+            if (property == default)
+            {
+                throw new MissingParserForMessageType(typeof(TMessage));
+            }
+
+            var parser = property.GetValue(null) as MessageParser<TMessage>;
+            return parser.ParseFrom(entry.ValueBytes);
         }
     }
 }

--- a/Source/Protobuf/Extensions.cs
+++ b/Source/Protobuf/Extensions.cs
@@ -79,6 +79,16 @@ namespace Dolittle.Protobuf
         }
 
         /// <summary>
+        /// Convert a <see cref="Execution.ExecutionContext"/> to <see cref="ByteString"/>.
+        /// </summary>
+        /// <param name="executionContext"><see cref="Execution.ExecutionContext"/> to convert from.</param>
+        /// <returns>Converted <see cref="ByteString"/>.</returns>
+        public static ByteString ToByteString(this Execution.ExecutionContext executionContext)
+        {
+            return executionContext.ToProtobuf().ToByteString();
+        }
+
+        /// <summary>
         /// Convert from <see cref="Claims"/> to <see cref="IEnumerable{T}"/> of <see cref="Security.Contracts.Claim"/>.
         /// </summary>
         /// <param name="claims"><see cref="Claims"/> to convert from.</param>

--- a/Source/Protobuf/MissingArgumentsHeaderOnCallContext.cs
+++ b/Source/Protobuf/MissingArgumentsHeaderOnCallContext.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Grpc.Core;
+
+namespace Dolittle.Protobuf
+{
+    /// <summary>
+    /// Exception that gets thrown when a <see cref="ServerCallContext"/> is missing a required arguments message in the header.
+    /// </summary>
+    public class MissingArgumentsHeaderOnCallContext : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MissingArgumentsHeaderOnCallContext"/> class.
+        /// </summary>
+        /// <param name="callContext">The <see cref="ServerCallContext"/> where header is missing.</param>
+        public MissingArgumentsHeaderOnCallContext(ServerCallContext callContext)
+            : base($"Missing arguments header on call of server method '{callContext.Method}'")
+        {
+        }
+    }
+}

--- a/Source/Protobuf/MissingParserForMessageType.cs
+++ b/Source/Protobuf/MissingParserForMessageType.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Google.Protobuf;
+using Grpc.Core;
+
+namespace Dolittle.Protobuf
+{
+    /// <summary>
+    /// Exception that gets thrown when a <see cref="ServerCallContext"/> is missing a required arguments message in the header.
+    /// </summary>
+    public class MissingParserForMessageType : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MissingParserForMessageType"/> class.
+        /// </summary>
+        /// <param name="type">The type of <see cref="IMessage"/> that does not have a parser.</param>
+        public MissingParserForMessageType(Type type)
+            : base($"Missing message parser for message type '{type.AssemblyQualifiedName}'")
+        {
+        }
+    }
+}

--- a/Specifications/Protobuf/for_Extensions/CallContext.cs
+++ b/Specifications/Protobuf/for_Extensions/CallContext.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+
+namespace Dolittle.Protobuf.for_Extensions
+{
+    public class CallContext : ServerCallContext
+    {
+        public CallContext()
+        {
+            RequestHeadersCore = new Metadata();
+        }
+
+        protected override string MethodCore => "SpecMethod";
+
+        protected override string HostCore => throw new NotImplementedException();
+
+        protected override string PeerCore => throw new NotImplementedException();
+
+        protected override DateTime DeadlineCore => throw new NotImplementedException();
+
+        protected override Metadata RequestHeadersCore { get; }
+
+        protected override CancellationToken CancellationTokenCore => throw new NotImplementedException();
+
+        protected override Metadata ResponseTrailersCore => throw new NotImplementedException();
+
+        protected override Status StatusCore { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        protected override WriteOptions WriteOptionsCore { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        protected override AuthContext AuthContextCore => throw new NotImplementedException();
+
+        protected override ContextPropagationToken CreatePropagationTokenCore(ContextPropagationOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override Task WriteResponseHeadersAsyncCore(Metadata responseHeaders)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Specifications/Protobuf/for_Extensions/MyMessage.cs
+++ b/Specifications/Protobuf/for_Extensions/MyMessage.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Google.Protobuf;
+using Google.Protobuf.Reflection;
+
+namespace Dolittle.Protobuf.for_Extensions
+{
+    public class MyMessage : IMessage<MyMessage>
+    {
+        public MessageDescriptor Descriptor => throw new NotImplementedException();
+
+        public int CalculateSize()
+        {
+            return 0;
+        }
+
+        public MyMessage Clone()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Equals([AllowNull] MyMessage other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void MergeFrom(MyMessage message)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void MergeFrom(CodedInputStream input)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteTo(CodedOutputStream output)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool Equals(object obj)
+        {
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return 0;
+        }
+    }
+}

--- a/Specifications/Protobuf/for_Extensions/when_adding_metadata_and_getting_it.cs
+++ b/Specifications/Protobuf/for_Extensions/when_adding_metadata_and_getting_it.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Machine.Specifications;
+
+namespace Dolittle.Protobuf.for_Extensions
+{
+    public class when_adding_metadata_and_getting_it
+    {
+        static Execution.Contracts.ExecutionContext execution_context;
+        static Execution.Contracts.ExecutionContext result;
+
+        Establish context = () =>
+        {
+            execution_context = new Execution.Contracts.ExecutionContext
+            {
+                Tenant = Guid.NewGuid().ToProtobuf(),
+                Microservice = Guid.NewGuid().ToProtobuf(),
+                CorrelationId = Guid.NewGuid().ToProtobuf(),
+            };
+
+            execution_context.Claims.AddRange(new[]
+            {
+                new Security.Contracts.Claim { Key = "First", Value = "FirstValue", ValueType = "FirstValueType" },
+                new Security.Contracts.Claim { Key = "Second", Value = "SecondValue", ValueType = "SecondValueType" }
+            });
+        };
+
+        Because of = () =>
+        {
+            var entry = execution_context.ToArgumentsMetadata();
+            var callContext = new CallContext();
+            callContext.RequestHeaders.Add(entry);
+            result = callContext.GetArgumentsMessage<Execution.Contracts.ExecutionContext>();
+        };
+
+        It should_be_equal = () => result.ShouldEqual(execution_context);
+    }
+}

--- a/Specifications/Protobuf/for_Extensions/when_getting_arguments_from_context_for_message_without_parser.cs
+++ b/Specifications/Protobuf/for_Extensions/when_getting_arguments_from_context_for_message_without_parser.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Machine.Specifications;
+
+namespace Dolittle.Protobuf.for_Extensions
+{
+    public class when_getting_arguments_from_context_for_message_without_parser
+    {
+        static CallContext call_context;
+        static Exception result;
+
+        Establish context = () =>
+        {
+            call_context = new CallContext();
+            call_context.RequestHeaders.Add(new Execution.Contracts.ExecutionContext().ToArgumentsMetadata());
+        };
+
+        Because of = () => result = Catch.Exception(() => call_context.GetArgumentsMessage<MyMessage>());
+
+        It should_throw_missing_parser_for_message_type = () => result.ShouldBeOfExactType<MissingParserForMessageType>();
+    }
+}

--- a/Specifications/Protobuf/for_Extensions/when_getting_arguments_from_context_without_arguments.cs
+++ b/Specifications/Protobuf/for_Extensions/when_getting_arguments_from_context_without_arguments.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Machine.Specifications;
+
+namespace Dolittle.Protobuf.for_Extensions
+{
+    public class when_getting_arguments_from_context_without_arguments
+    {
+        static CallContext call_context;
+        static Exception result;
+
+        Establish context = () => call_context = new CallContext();
+
+        Because of = () => result = Catch.Exception(() => call_context.GetArgumentsMessage<Execution.Contracts.ExecutionContext>());
+
+        It should_throw_missing_arguments_header_on_call_context = () => result.ShouldBeOfExactType<MissingArgumentsHeaderOnCallContext>();
+    }
+}


### PR DESCRIPTION
This allows for easily adding additional arguments to go on calls in a consistent way.
Arguments are then modelled as protobuf messages and serialized to byte arrays. It will consistently set the correct metadata entry by name.

This is very helpful when we for instance have duplex stream calls and no way to specify arguments we want to pass along in the service definition.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1160742863384676)
