### PR TITLE
Change Reason.Create to enforce a Guid id

### DIFF
--- a/Source/Rules/Reason.cs
+++ b/Source/Rules/Reason.cs
@@ -46,11 +46,11 @@ namespace Dolittle.Rules
         /// The format of the Guid has to be :
         /// 00000000-0000-0000-0000-000000000000.
         /// </remarks>
-        public static Reason Create(string id, string title, string description = "")
+        public static Reason Create(Guid id, string title, string description = "")
         {
             return new Reason
             {
-                Id = Guid.Parse(id),
+                Id = id,
                 Title = title,
                 Description = description
             };

--- a/Source/Validation/Rules/Email.cs
+++ b/Source/Validation/Rules/Email.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Reflection;
 using Dolittle.Rules;
 
@@ -14,7 +15,7 @@ namespace Dolittle.Validation.Rules
         /// <summary>
         /// When an email is invalid, this is the reason given.
         /// </summary>
-        public static Reason InvalidEMailReason = Reason.Create("A62F369F-9C92-4A06-96C3-654AB0E15119", "Invalid EMail '{Value}'");
+        public static Reason InvalidEMailReason = Reason.Create(new Guid("A62F369F-9C92-4A06-96C3-654AB0E15119"), "Invalid EMail '{Value}'");
 
         const string _expression = @"((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$";
         static readonly System.Text.RegularExpressions.Regex _regex = new System.Text.RegularExpressions.Regex(_expression);

--- a/Source/Validation/Rules/NotNull.cs
+++ b/Source/Validation/Rules/NotNull.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Reflection;
 using Dolittle.Rules;
 
@@ -14,7 +15,7 @@ namespace Dolittle.Validation.Rules
         /// <summary>
         /// When a value is null, this is the reason given.
         /// </summary>
-        public static Reason ValueIsNull = Reason.Create("712D26C6-A40F-4A3D-8C69-1475E761A1CF", "Value is null");
+        public static Reason ValueIsNull = Reason.Create(new Guid("712D26C6-A40F-4A3D-8C69-1475E761A1CF"), "Value is null");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NotNull"/> class.

--- a/Source/Validation/Rules/Reasons.cs
+++ b/Source/Validation/Rules/Reasons.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Dolittle.Rules;
 
 namespace Dolittle.Validation.Rules
@@ -13,26 +14,26 @@ namespace Dolittle.Validation.Rules
         /// <summary>
         /// When a value is equal and it is not not allowed to be equal, this is the reason given.
         /// </summary>
-        public static Reason ValueIsEqual = Reason.Create("CEFA9147-5F13-4C82-B609-C64582EC33AB", "Value {LeftHand} is equal {RightHand}");
+        public static Reason ValueIsEqual = Reason.Create(new Guid("CEFA9147-5F13-4C82-B609-C64582EC33AB"), "Value {LeftHand} is equal {RightHand}");
 
         /// <summary>
         /// When a value is less than the specified greater than value, this is the reason given.
         /// </summary>
-        public static Reason ValueIsLessThan = Reason.Create("8CFB5B51-55E6-41A6-A01A-33F83E141CF2", "Value {LeftHand} is less than {RightHand}");
+        public static Reason ValueIsLessThan = Reason.Create(new Guid("8CFB5B51-55E6-41A6-A01A-33F83E141CF2"), "Value {LeftHand} is less than {RightHand}");
 
         /// <summary>
         /// When a value was greater than the specified less than value, this is the reason given.
         /// </summary>
-        public static Reason ValueIsGreaterThan = Reason.Create("6C489DB3-DE0A-45BA-A547-5A6E3AD3F303", "Value {LeftHand} is greater than {RightHand}");
+        public static Reason ValueIsGreaterThan = Reason.Create(new Guid("6C489DB3-DE0A-45BA-A547-5A6E3AD3F303"), "Value {LeftHand} is greater than {RightHand}");
 
         /// <summary>
         /// When something is longer than it should, this is the reason given.
         /// </summary>
-        public static Reason LengthIsTooLong = Reason.Create("D9675214-A6A4-439F-8D8E-AF0A48BD1BF0", "Length {Length} is too long");
+        public static Reason LengthIsTooLong = Reason.Create(new Guid("D9675214-A6A4-439F-8D8E-AF0A48BD1BF0"), "Length {Length} is too long");
 
         /// <summary>
         /// When something is longer than it should, this is the reason given.
         /// </summary>
-        public static Reason LengthIsTooShort = Reason.Create("E0F8D478-A353-4926-893E-DD367E2F2ACF", "Length {Length} is too short");
+        public static Reason LengthIsTooShort = Reason.Create(new Guid("E0F8D478-A353-4926-893E-DD367E2F2ACF"), "Length {Length} is too short");
     }
 }

--- a/Source/Validation/Rules/Regex.cs
+++ b/Source/Validation/Rules/Regex.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Reflection;
 using Dolittle.Rules;
 
@@ -14,7 +15,7 @@ namespace Dolittle.Validation.Rules
         /// <summary>
         /// When a string does not conform to the specified expression, this is the reason given.
         /// </summary>
-        public static Reason NotConformingToExpression = Reason.Create("BE58A125-40DB-47EA-B260-37F7AF4455C5", "Value '{Value}' does not conform to regular expression");
+        public static Reason NotConformingToExpression = Reason.Create(new Guid("BE58A125-40DB-47EA-B260-37F7AF4455C5"), "Value '{Value}' does not conform to regular expression");
 
         readonly System.Text.RegularExpressions.Regex _actualRegex;
 

--- a/Source/Validation/Rules/Required.cs
+++ b/Source/Validation/Rules/Required.cs
@@ -16,17 +16,17 @@ namespace Dolittle.Validation.Rules
         /// <summary>
         /// When a value is null, this is the reason given.
         /// </summary>
-        public static Reason ValueIsNull = Reason.Create("712D26C6-A40F-4A3D-8C69-1475E761A1CF", "Value is null");
+        public static Reason ValueIsNull = Reason.Create(new Guid("712D26C6-A40F-4A3D-8C69-1475E761A1CF"), "Value is null");
 
         /// <summary>
         /// When a value is not specified, this is the reason given.
         /// </summary>
-        public static Reason StringIsEmpty = Reason.Create("6DE903D6-014C-4B07-B5D3-C3F28677C1A6", "String is empty");
+        public static Reason StringIsEmpty = Reason.Create(new Guid("6DE903D6-014C-4B07-B5D3-C3F28677C1A6"), "String is empty");
 
         /// <summary>
         /// When a value is not specified, this is the reason given.
         /// </summary>
-        public static Reason ValueNotSpecified = Reason.Create("5F790FC3-5C7D-4F3A-B1E9-8F85FAF7176D", "Valud not specified");
+        public static Reason ValueNotSpecified = Reason.Create(new Guid("5F790FC3-5C7D-4F3A-B1E9-8F85FAF7176D"), "Valud not specified");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Required"/> class.

--- a/Source/Validation/ValueRule.cs
+++ b/Source/Validation/ValueRule.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Reflection;
 using Dolittle.Rules;
 
@@ -14,7 +15,7 @@ namespace Dolittle.Validation
         /// <summary>
         /// When a value is of the wrong type, this is the reason given for breaking a rule.
         /// </summary>
-        public static Reason ValueTypeMismatch = Reason.Create("150757B0-8118-42FB-A8C4-2D49E7AC3AFD", "Value type mismatch - expected {Expected} got {Type}");
+        public static Reason ValueTypeMismatch = Reason.Create(new Guid("150757B0-8118-42FB-A8C4-2D49E7AC3AFD"), "Value type mismatch - expected {Expected} got {Type}");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ValueRule"/> class.

--- a/Specifications/Rules/for_BrokenRule/when_adding_two_causes.cs
+++ b/Specifications/Rules/for_BrokenRule/when_adding_two_causes.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Machine.Specifications;
 using Moq;
 using It = Machine.Specifications.It;
@@ -13,8 +14,8 @@ namespace Dolittle.Rules.for_BrokenRule
         static Mock<IRuleContext> rule_context;
         static object instance;
         static BrokenRule broken_rule;
-        static Reason first_reason = Reason.Create("2da82a45-e779-4823-ae12-c02023ee8e5f", "First reason");
-        static Reason second_reason = Reason.Create("5e536622-5b92-44ea-ba83-cfa14d5029b4", "Second reason");
+        static Reason first_reason = Reason.Create(new Guid("2da82a45-e779-4823-ae12-c02023ee8e5f"), "First reason");
+        static Reason second_reason = Reason.Create(new Guid("5e536622-5b92-44ea-ba83-cfa14d5029b4"), "Second reason");
 
         static Cause first_cause;
         static Cause second_cause;

--- a/Specifications/Rules/for_Cause/when_creating_with_two_arguments_and_title_and_description_using_them.cs
+++ b/Specifications/Rules/for_Cause/when_creating_with_two_arguments_and_title_and_description_using_them.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Machine.Specifications;
 
 namespace Dolittle.Rules.for_Cause
@@ -14,7 +15,7 @@ namespace Dolittle.Rules.for_Cause
         static string expected_title = $"The answer is {answer}, the question is {question}. Does that {answer}?";
         static string expected_description = $"The long answer is {answer} with the longer question is {question}. Does that {answer}?";
 
-        static Reason reason = Reason.Create("d05cb07b-55f7-4c80-b306-408c69a0ea9d", title, description);
+        static Reason reason = Reason.Create(new Guid("d05cb07b-55f7-4c80-b306-408c69a0ea9d"), title, description);
         static Cause instance;
         Because of = () => instance = reason.WithArgs(new { Answer = answer, Question = question });
         It should_have_the_correct_interpolated_title = () => instance.Title.ShouldEqual(expected_title);

--- a/Specifications/Rules/for_MethodRule/when_evaluating_failed_method.cs
+++ b/Specifications/Rules/for_MethodRule/when_evaluating_failed_method.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Machine.Specifications;
 using Moq;
 using It = Machine.Specifications.It;
@@ -10,7 +11,7 @@ namespace Dolittle.Rules.for_MethodRule
     public class when_evaluating_failed_method
     {
         const string rule_name = "This is the rule";
-        static Reason reason = Reason.Create("f2049be1-c421-45d1-bdd5-a9eb4530c3dc", "Title", "Description");
+        static Reason reason = Reason.Create(new Guid("f2049be1-c421-45d1-bdd5-a9eb4530c3dc"), "Title", "Description");
         static Cause cause;
         static Mock<IRuleContext> rule_context;
         static object instance;

--- a/Specifications/Rules/for_Reason/when_creating.cs
+++ b/Specifications/Rules/for_Reason/when_creating.cs
@@ -1,20 +1,21 @@
 ﻿// Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Machine.Specifications;
 
 namespace Dolittle.Rules.Specs.for_Reason
 {
     public class when_creating
     {
-        static string id = "3847286b-b508-4738-8975-f08383999f5a";
+        static Guid id = new Guid("3847286b-b508-4738-8975-f08383999f5a");
         static string title = "Some Title";
         static string description = "Some description";
         static Reason reason;
 
         Because of = () => reason = Reason.Create(id, title, description);
 
-        It should_have_the_id_set = () => reason.Id.ToString().ToLowerInvariant().ShouldEqual(id);
+        It should_have_the_id_set = () => reason.Id.ShouldEqual(id);
         It should_have_title_set = () => reason.Title.ShouldEqual(title);
         It should_have_description_set = () => reason.Description.ShouldEqual(description);
     }

--- a/Specifications/Rules/for_Reason/when_getting_instance_with_args.cs
+++ b/Specifications/Rules/for_Reason/when_getting_instance_with_args.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Machine.Specifications;
 
 namespace Dolittle.Rules.Specs.for_Reason
@@ -11,7 +12,7 @@ namespace Dolittle.Rules.Specs.for_Reason
         const string description = "With a description";
         const string first_argument = "Fourty Two";
         const int second_argument = 42;
-        static Reason reason = Reason.Create("2319436d-91c8-43f6-b342-d38906bb0c3f", title, description);
+        static Reason reason = Reason.Create(new Guid("2319436d-91c8-43f6-b342-d38906bb0c3f"), title, description);
 
         static object args;
 

--- a/Specifications/Rules/for_Reason/when_getting_instance_without_args.cs
+++ b/Specifications/Rules/for_Reason/when_getting_instance_without_args.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Machine.Specifications;
 
 namespace Dolittle.Rules.Specs.for_Reason
@@ -9,7 +10,7 @@ namespace Dolittle.Rules.Specs.for_Reason
     {
         const string title = "Some title";
         const string description = "With a description";
-        static Reason reason = Reason.Create("2319436d-91c8-43f6-b342-d38906bb0c3f", title, description);
+        static Reason reason = Reason.Create(new Guid("2319436d-91c8-43f6-b342-d38906bb0c3f"), title, description);
 
         static Cause instance;
 

--- a/Specifications/Rules/for_RuleContext/when_failing_with_two_callbacks_registered.cs
+++ b/Specifications/Rules/for_RuleContext/when_failing_with_two_callbacks_registered.cs
@@ -23,7 +23,7 @@ namespace Dolittle.Rules.for_RuleContext
         {
             rule_mock = new Mock<IRule>();
             instance = new object();
-            reason = Reason.Create(Guid.NewGuid().ToString(), "Some reason");
+            reason = Reason.Create(Guid.NewGuid(), "Some reason");
             cause = reason.NoArgs();
             rule_context = new RuleContext(instance);
 

--- a/Specifications/Rules/for_RuleEvaluationResult/when_creating_through_fail_with_two_causes.cs
+++ b/Specifications/Rules/for_RuleEvaluationResult/when_creating_through_fail_with_two_causes.cs
@@ -1,14 +1,15 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Machine.Specifications;
 
 namespace Dolittle.Rules.for_RuleEvaluationResult
 {
     public class when_creating_through_fail_with_two_causes
     {
-        static Reason first_reason = Reason.Create("ffa1f234-2345-46c4-b4c3-dda1f73f5c03", "First reason");
-        static Reason second_reason = Reason.Create("296bac42-025a-4697-824e-d5019cf3f1c8", "Second reason");
+        static Reason first_reason = Reason.Create(new Guid("ffa1f234-2345-46c4-b4c3-dda1f73f5c03"), "First reason");
+        static Reason second_reason = Reason.Create(new Guid("296bac42-025a-4697-824e-d5019cf3f1c8"), "Second reason");
         static Cause first_cause;
         static Cause second_cause;
         static RuleEvaluationResult result;

--- a/Specifications/Rules/for_RuleEvaluationResult/when_creating_with_two_causes.cs
+++ b/Specifications/Rules/for_RuleEvaluationResult/when_creating_with_two_causes.cs
@@ -1,14 +1,15 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Machine.Specifications;
 
 namespace Dolittle.Rules.for_RuleEvaluationResult
 {
     public class when_creating_with_two_causes
     {
-        static Reason first_reason = Reason.Create("ffa1f234-2345-46c4-b4c3-dda1f73f5c03", "First reason");
-        static Reason second_reason = Reason.Create("296bac42-025a-4697-824e-d5019cf3f1c8", "Second reason");
+        static Reason first_reason = Reason.Create(new Guid("ffa1f234-2345-46c4-b4c3-dda1f73f5c03"), "First reason");
+        static Reason second_reason = Reason.Create(new Guid("296bac42-025a-4697-824e-d5019cf3f1c8"), "Second reason");
         static Cause first_cause;
         static Cause second_cause;
         static RuleEvaluationResult result;

--- a/Specifications/Rules/for_RuleSetEvaluation/when_evaluating_with_two_broken_rules_with_two_causes_each.cs
+++ b/Specifications/Rules/for_RuleSetEvaluation/when_evaluating_with_two_broken_rules_with_two_causes_each.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Linq;
 using Machine.Specifications;
 using Moq;
@@ -10,10 +11,10 @@ namespace Dolittle.Rules.for_RuleSetEvaluation
 {
     public class when_evaluating_with_two_broken_rules_with_two_causes_each
     {
-        static Reason first_rule_first_reason = Reason.Create("e8a91403-35f1-43e9-ab07-ddc677d4dddd", "First Rule First Reason");
-        static Reason first_rule_second_reason = Reason.Create("3ea2a5ff-6d32-4211-806a-4fd5bada6a5a", "First Rule Second Reason");
-        static Reason second_rule_first_reason = Reason.Create("e5179c37-b57d-422d-8d8f-4d754b833702", "Second Rule First Reason");
-        static Reason second_rule_second_reason = Reason.Create("e2a01773-33db-457b-91e5-83e9563417e7", "Second Rule Second Reason");
+        static Reason first_rule_first_reason = Reason.Create(new Guid("e8a91403-35f1-43e9-ab07-ddc677d4dddd"), "First Rule First Reason");
+        static Reason first_rule_second_reason = Reason.Create(new Guid("3ea2a5ff-6d32-4211-806a-4fd5bada6a5a"), "First Rule Second Reason");
+        static Reason second_rule_first_reason = Reason.Create(new Guid("e5179c37-b57d-422d-8d8f-4d754b833702"), "Second Rule First Reason");
+        static Reason second_rule_second_reason = Reason.Create(new Guid("e2a01773-33db-457b-91e5-83e9563417e7"), "Second Rule Second Reason");
         static Cause first_rule_first_cause;
         static Cause first_rule_second_cause;
         static Cause second_rule_first_cause;


### PR DESCRIPTION
The current .Create accepts any string and crashes run-time. Let's
use the compiler to remove a potential run-time error.

If we need it to be a Guid we should not allow strings, even if that
makes the method slightly easier to use. It does so at the expense
of making run-time errors more likely.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1162131719318871)
