### PR TITLE
Removing async postfix

### DIFF
--- a/Source/Resilience/AsyncPolicy.cs
+++ b/Source/Resilience/AsyncPolicy.cs
@@ -41,28 +41,28 @@ namespace Dolittle.Resilience
         public IAsyncPolicy DelegatedPolicy { get; }
 
         /// <inheritdoc/>
-        public Task ExecuteAsync(Func<Task> action) => ExecuteAsync(_ => action(), CancellationToken.None);
+        public Task Execute(Func<Task> action) => Execute(_ => action(), CancellationToken.None);
 
         /// <inheritdoc/>
-        public Task ExecuteAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken) => ExecuteAsync(action, false, cancellationToken);
+        public Task Execute(Func<CancellationToken, Task> action, CancellationToken cancellationToken) => Execute(action, false, cancellationToken);
 
         /// <inheritdoc/>
-        public Task ExecuteAsync(Func<CancellationToken, Task> action, bool continueOnCapturedContext, CancellationToken cancellationToken)
+        public Task Execute(Func<CancellationToken, Task> action, bool continueOnCapturedContext, CancellationToken cancellationToken)
         {
-            if (DelegatedPolicy != null) return DelegatedPolicy.ExecuteAsync(action, continueOnCapturedContext, cancellationToken);
+            if (DelegatedPolicy != null) return DelegatedPolicy.Execute(action, continueOnCapturedContext, cancellationToken);
             else return UnderlyingPolicy.ExecuteAsync(action, cancellationToken, continueOnCapturedContext);
         }
 
         /// <inheritdoc/>
-        public Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> action) => ExecuteAsync(_ => action(), CancellationToken.None);
+        public Task<TResult> Execute<TResult>(Func<Task<TResult>> action) => Execute(_ => action(), CancellationToken.None);
 
         /// <inheritdoc/>
-        public Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken) => ExecuteAsync(action, false, cancellationToken);
+        public Task<TResult> Execute<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken) => Execute(action, false, cancellationToken);
 
         /// <inheritdoc/>
-        public Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, bool continueOnCapturedContext, CancellationToken cancellationToken)
+        public Task<TResult> Execute<TResult>(Func<CancellationToken, Task<TResult>> action, bool continueOnCapturedContext, CancellationToken cancellationToken)
         {
-            if (DelegatedPolicy != null) return DelegatedPolicy.ExecuteAsync(action, continueOnCapturedContext, cancellationToken);
+            if (DelegatedPolicy != null) return DelegatedPolicy.Execute(action, continueOnCapturedContext, cancellationToken);
             return UnderlyingPolicy.ExecuteAsync(action, cancellationToken, continueOnCapturedContext);
         }
     }

--- a/Source/Resilience/IAsyncPolicy.cs
+++ b/Source/Resilience/IAsyncPolicy.cs
@@ -19,7 +19,7 @@ namespace Dolittle.Resilience
         /// <param name="action"><see cref="Func{Task}"/> to execute.</param>
         /// <returns>The Task.</returns>
         [DebuggerStepThrough]
-        Task ExecuteAsync(Func<Task> action);
+        Task Execute(Func<Task> action);
 
         /// <summary>
         /// Execute an async action within the policy.
@@ -28,7 +28,7 @@ namespace Dolittle.Resilience
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The Task.</returns>
         [DebuggerStepThrough]
-        Task ExecuteAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken);
+        Task Execute(Func<CancellationToken, Task> action, CancellationToken cancellationToken);
 
         /// <summary>
         /// Execute an async action within the policy.
@@ -38,7 +38,7 @@ namespace Dolittle.Resilience
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The Task.</returns>
         [DebuggerStepThrough]
-        Task ExecuteAsync(Func<CancellationToken, Task> action, bool continueOnCapturedContext, CancellationToken cancellationToken);
+        Task Execute(Func<CancellationToken, Task> action, bool continueOnCapturedContext, CancellationToken cancellationToken);
 
         /// <summary>
         /// /// Executes an action within the policy and returns the result from the action.
@@ -47,7 +47,7 @@ namespace Dolittle.Resilience
         /// <param name="action"><see cref="Func{Task}"/> to call.</param>
         /// <returns>Result from the action.</returns>
         [DebuggerStepThrough]
-        Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> action);
+        Task<TResult> Execute<TResult>(Func<Task<TResult>> action);
 
         /// <summary>
         /// Executes an action within the policy and returns the result from the action.
@@ -57,7 +57,7 @@ namespace Dolittle.Resilience
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>Result from the action.</returns>
         [DebuggerStepThrough]
-        Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken);
+        Task<TResult> Execute<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken);
 
         /// <summary>
         /// Executes an action within the policy and returns the result from the action.
@@ -68,6 +68,6 @@ namespace Dolittle.Resilience
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>Result from the action.</returns>
         [DebuggerStepThrough]
-        Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, bool continueOnCapturedContext, CancellationToken cancellationToken);
+        Task<TResult> Execute<TResult>(Func<CancellationToken, Task<TResult>> action, bool continueOnCapturedContext, CancellationToken cancellationToken);
     }
 }

--- a/Source/Resilience/PassThroughAsyncPolicy.cs
+++ b/Source/Resilience/PassThroughAsyncPolicy.cs
@@ -18,21 +18,21 @@ namespace Dolittle.Resilience
     public class PassThroughAsyncPolicy : IAsyncPolicy
     {
         /// <inheritdoc/>
-        public Task ExecuteAsync(Func<Task> action) => ExecuteAsync(_ => action(), CancellationToken.None);
+        public Task Execute(Func<Task> action) => Execute(_ => action(), CancellationToken.None);
 
         /// <inheritdoc/>
-        public Task ExecuteAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken) => ExecuteAsync(action, false, CancellationToken.None);
+        public Task Execute(Func<CancellationToken, Task> action, CancellationToken cancellationToken) => Execute(action, false, CancellationToken.None);
 
         /// <inheritdoc/>
-        public async Task ExecuteAsync(Func<CancellationToken, Task> action, bool continueOnCapturedContext, CancellationToken cancellationToken) => await action(cancellationToken).ConfigureAwait(continueOnCapturedContext);
+        public async Task Execute(Func<CancellationToken, Task> action, bool continueOnCapturedContext, CancellationToken cancellationToken) => await action(cancellationToken).ConfigureAwait(continueOnCapturedContext);
 
         /// <inheritdoc/>
-        public Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> action) => ExecuteAsync(_ => action(), CancellationToken.None);
+        public Task<TResult> Execute<TResult>(Func<Task<TResult>> action) => Execute(_ => action(), CancellationToken.None);
 
         /// <inheritdoc/>
-        public Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken) => ExecuteAsync(action, false, CancellationToken.None);
+        public Task<TResult> Execute<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken) => Execute(action, false, CancellationToken.None);
 
         /// <inheritdoc/>
-        public async Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, bool continueOnCapturedContext, CancellationToken cancellationToken) => await action(cancellationToken).ConfigureAwait(continueOnCapturedContext);
+        public async Task<TResult> Execute<TResult>(Func<CancellationToken, Task<TResult>> action, bool continueOnCapturedContext, CancellationToken cancellationToken) => await action(cancellationToken).ConfigureAwait(continueOnCapturedContext);
     }
 }

--- a/Specifications/Resilience/for_AsyncPolicy/when_executing_action/with_no_result_with_delegated_policy.cs
+++ b/Specifications/Resilience/for_AsyncPolicy/when_executing_action/with_no_result_with_delegated_policy.cs
@@ -21,8 +21,8 @@ namespace Dolittle.Resilience.for_AsyncPolicy.when_executing_action
             policy = new AsyncPolicy(delegated_policy.Object);
         };
 
-        Because of = () => policy.ExecuteAsync(() => Task.CompletedTask).GetAwaiter().GetResult();
+        Because of = () => policy.Execute(() => Task.CompletedTask).GetAwaiter().GetResult();
 
-        It should_forward_call_to_delegated_policy = () => delegated_policy.Verify(_ => _.ExecuteAsync(Moq.It.IsAny<Func<CancellationToken, Task>>(), Moq.It.IsAny<bool>(), Moq.It.IsAny<CancellationToken>()), Times.Once);
+        It should_forward_call_to_delegated_policy = () => delegated_policy.Verify(_ => _.Execute(Moq.It.IsAny<Func<CancellationToken, Task>>(), Moq.It.IsAny<bool>(), Moq.It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/Specifications/Resilience/for_AsyncPolicy/when_executing_action/with_no_result_with_underlying_policy.cs
+++ b/Specifications/Resilience/for_AsyncPolicy/when_executing_action/with_no_result_with_underlying_policy.cs
@@ -14,7 +14,7 @@ namespace Dolittle.Resilience.for_AsyncPolicy.when_executing_action
 
         Establish context = () => policy = new AsyncPolicy(Polly.Policy.NoOpAsync());
 
-        Because of = () => policy.ExecuteAsync(() =>
+        Because of = () => policy.Execute(() =>
         {
             called = true;
             return Task.CompletedTask;

--- a/Specifications/Resilience/for_AsyncPolicy/when_executing_action/with_result_with_delegated_policy.cs
+++ b/Specifications/Resilience/for_AsyncPolicy/when_executing_action/with_result_with_delegated_policy.cs
@@ -21,10 +21,10 @@ namespace Dolittle.Resilience.for_AsyncPolicy.when_executing_action
         {
             delegated_policy = new Mock<IAsyncPolicy>();
             policy = new AsyncPolicy(delegated_policy.Object);
-            delegated_policy.Setup(_ => _.ExecuteAsync<string>(Moq.It.IsAny<Func<CancellationToken, Task<string>>>(), Moq.It.IsAny<bool>(), Moq.It.IsAny<CancellationToken>())).Returns(() => Task.FromResult(expected_result));
+            delegated_policy.Setup(_ => _.Execute<string>(Moq.It.IsAny<Func<CancellationToken, Task<string>>>(), Moq.It.IsAny<bool>(), Moq.It.IsAny<CancellationToken>())).Returns(() => Task.FromResult(expected_result));
         };
 
-        Because of = () => result = policy.ExecuteAsync(() => Task.FromResult(expected_result)).GetAwaiter().GetResult();
+        Because of = () => result = policy.Execute(() => Task.FromResult(expected_result)).GetAwaiter().GetResult();
 
         It should_forward_call_to_delegated_policy_and_return_result = () => result.ShouldEqual(expected_result);
     }

--- a/Specifications/Resilience/for_AsyncPolicy/when_executing_action/with_result_with_underlying_policy.cs
+++ b/Specifications/Resilience/for_AsyncPolicy/when_executing_action/with_result_with_underlying_policy.cs
@@ -15,7 +15,7 @@ namespace Dolittle.Resilience.for_AsyncPolicy.when_executing_action
 
         Establish context = () => policy = new AsyncPolicy(Polly.Policy.NoOpAsync());
 
-        Because of = () => result = policy.ExecuteAsync(() => Task.FromResult(expected_result)).GetAwaiter().GetResult();
+        Because of = () => result = policy.Execute(() => Task.FromResult(expected_result)).GetAwaiter().GetResult();
 
         It should_forward_call_to_delegated_policy_and_return_result = () => result.ShouldEqual(expected_result);
     }


### PR DESCRIPTION
We don't want to have PostFixes on the API if not needed - so removing the `Async` postfix for the methods on all Policies as the type indicates that these are async, plus the signature of the method is clear as well.

This slipped through the cracks during pull request review.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1166906043058358)
