### PR TITLE
Self binding for all bindings based on type

### DIFF
--- a/Source/DependencyInversion.Autofac/ContainerBuilderExtensions.cs
+++ b/Source/DependencyInversion.Autofac/ContainerBuilderExtensions.cs
@@ -76,7 +76,9 @@ namespace Dolittle.DependencyInversion.Autofac
                     {
                         case Strategies.Type type:
                             {
-                                var registrationBuilder = containerBuilder.RegisterGeneric(type.Target).As(binding.Service);
+                                var registrationBuilder = containerBuilder.RegisterGeneric(type.Target)
+                                    .AsSelf()
+                                    .As(binding.Service);
                                 if (binding.Scope is Scopes.Singleton) registrationBuilder = registrationBuilder.SingleInstance();
                             }
 
@@ -117,7 +119,9 @@ namespace Dolittle.DependencyInversion.Autofac
                     {
                         case Strategies.Type type:
                             {
-                                var registrationBuilder = containerBuilder.RegisterType(type.Target).As(binding.Service);
+                                var registrationBuilder = containerBuilder.RegisterType(type.Target)
+                                    .AsSelf()
+                                    .As(binding.Service);
                                 if (binding.Scope is Scopes.Singleton) registrationBuilder = registrationBuilder.SingleInstance();
                             }
 


### PR DESCRIPTION
This adds `.AsSelf()` for all type based bindings. This allows one to ask the container for an instance based on the concrete type in addition to its implementing interface and it will use the same binding for this.

The problem we ran into was when leveraging `IInstancesOf<>` which calls the container and asks for a concrete instance and the type also has an interface that typically follows the convention `IFoo` -> `Foo` in addition to an interface used as marking for discovery, taking a dependency to `IFoo` in another place would not follow same binding and honor the same lifecycle - for instance `Singleton` or `SingletonPerTenant`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1169872957972387)
