### PR TITLE
Fix ReverseCallDispatcher

### DIFF
--- a/Source/Services/IReverseCallDispatcher.cs
+++ b/Source/Services/IReverseCallDispatcher.cs
@@ -33,9 +33,13 @@ namespace Dolittle.Services
         Task Call(TRequest request, Func<TResponse, Task> callback);
 
         /// <summary>
-        /// Wait till client is disconnected. This will block.
+        /// Starts handling the reverse calls and returns a task that represents the processing of these calls.
         /// </summary>
+        /// <remarks>
+        /// If the handling of the calls finishes all future calls to this method will return the same task as the first time.
+        /// If this task throws an <see cref="Exception" /> then all future calls to this method will throw the same <see cref="Exception" />.
+        /// </remarks>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task WaitTillDisconnected();
+        Task HandleCalls();
     }
 }

--- a/Source/Services/IReverseCallDispatchers.cs
+++ b/Source/Services/IReverseCallDispatchers.cs
@@ -24,7 +24,12 @@ namespace Dolittle.Services
         /// <typeparam name="TResponse">Type of <see cref="IMessage"/> for the responses from the client.</typeparam>
         /// <typeparam name="TRequest">Type of <see cref="IMessage"/> for the requests to the client.</typeparam>
         /// <returns>A <see cref="IReverseCallDispatcher{TResponse, TRequest}"/>.</returns>
-        IReverseCallDispatcher<TResponse, TRequest> GetDispatcherFor<TResponse, TRequest>(IAsyncStreamReader<TResponse> responseStream, IServerStreamWriter<TRequest> requestStream, ServerCallContext context, Expression<Func<TResponse, ulong>> responseProperty, Expression<Func<TRequest, ulong>> requestProperty)
+        IReverseCallDispatcher<TResponse, TRequest> GetDispatcherFor<TResponse, TRequest>(
+            IAsyncStreamReader<TResponse> responseStream,
+            IServerStreamWriter<TRequest> requestStream,
+            ServerCallContext context,
+            Expression<Func<TResponse, ulong>> responseProperty,
+            Expression<Func<TRequest, ulong>> requestProperty)
             where TResponse : IMessage
             where TRequest : IMessage;
     }

--- a/Source/Services/ReverseCallDispatcher.cs
+++ b/Source/Services/ReverseCallDispatcher.cs
@@ -39,6 +39,7 @@ namespace Dolittle.Services
         readonly Task _handleResponse;
         ulong _lastCallNumber = 0;
         ulong _lastResolvedCallNumber = 0;
+        bool _finishedHandlingResponse;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ReverseCallDispatcher{TResponse, TRequest}"/> class.
@@ -110,7 +111,7 @@ namespace Dolittle.Services
 
         async Task HandleResponseProcessing()
         {
-            while (!_context.CancellationToken.IsCancellationRequested)
+            while (!_context.CancellationToken.IsCancellationRequested && !_finishedHandlingResponse)
             {
                 await Task.Delay(50).ConfigureAwait(false);
 
@@ -149,6 +150,8 @@ namespace Dolittle.Services
                     }
                 }
             }
+
+            _finishedHandlingResponse = true;
         }
 
         bool TryResolve(TResponse response)


### PR DESCRIPTION
This PR fixes an issue where you could have exceptions occuring in the two independently running tasks without them affecting the connection in any way. The processing would simply just stop without anyone noticing. 
Changes:
* Combine the two running tasks related to queueing responses and processing them to one internal task. If one of them fails or finishes both of them finishes. In this way we don't allow un-freed resources.
* WaitTillDisconnected is now called HandleCalls. It  returns the task which represents the two internal tasks. If any of those tasks throw an exception this call will throw that exception. Multiple calls to this function will do the exact same thing as the first time it is called

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1170477274488656)
