### PR TITLE
Fix IContainer and GetContainer bindings during and after booting

### DIFF
--- a/Source/DependencyInversion.Booting/BootContainer.cs
+++ b/Source/DependencyInversion.Booting/BootContainer.cs
@@ -34,15 +34,6 @@ namespace Dolittle.DependencyInversion.Booting
             newBindingsNotifier.SubscribeTo(_ => _.ToDictionary(_ => _.Service, _ => _.Strategy).ForEach(_bindings.Add));
         }
 
-        /// <summary>
-        /// Method that gets called when <see cref="IContainer"/> is ready.
-        /// </summary>
-        /// <param name="container"><see cref="IContainer"/> instance.</param>
-        internal static void ContainerReady(IContainer container)
-        {
-            _container = container;
-        }
-
         /// <inheritdoc/>
         public T Get<T>()
         {
@@ -64,6 +55,15 @@ namespace Dolittle.DependencyInversion.Booting
                 throw new TypeNotBoundInContainer(type, _bindings.Select(_ => _.Key));
 
             return Create(type);
+        }
+
+        /// <summary>
+        /// Method that gets called when <see cref="IContainer"/> is ready.
+        /// </summary>
+        /// <param name="container"><see cref="IContainer"/> instance.</param>
+        internal static void ContainerReady(IContainer container)
+        {
+            _container = container;
         }
 
         object InstantiateBinding(IActivationStrategy strategy, Type type) => strategy switch

--- a/Source/Hosting.Microsoft/ServiceProviderFactory.cs
+++ b/Source/Hosting.Microsoft/ServiceProviderFactory.cs
@@ -69,7 +69,7 @@ namespace Dolittle.Hosting.Microsoft
             try
             {
                 var container = serviceProvider.GetService(typeof(IContainer)) as IContainer;
-                DependencyInversion.Booting.BootContainer.ContainerReady(container);
+                DependencyInversion.Booting.Boot.ContainerReady(container);
                 BootStages.ContainerReady(container);
 
                 var logMessageWriterCreatorProviders = container.Get<IInstancesOf<ICanProvideLogMessageWriterCreators>>();


### PR DESCRIPTION
This PR reverts an incorrect fix in a07c9c263eaa2aaf3a0e19822145a6182f99dccc.

My understanding was that the bindings in the `BootContainer` propagated out to the results of the booting process, which turns out to be incorrect.

This PR brings back the binding to `IContainer` and `GetContainer` the way they were before in the "Container" boot stage, but also informs any `BootContainer` that the container is ready - so any components that have gotten a hold of the `BootContainer` as the container during the boot stages, will after booting use the final container to get services.

I have tested these changes on two projects and confirmed that they fix the BuildTool issue and does not break any other process.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1170638140332289)
