### PR TITLE
Suggested new implementation of reverse call dispatcher.

### DIFF
--- a/Source/Services/CannotPerformCallOnCompletedReverseCallConnection.cs
+++ b/Source/Services/CannotPerformCallOnCompletedReverseCallConnection.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Dolittle.Services
+{
+    /// <summary>
+    /// Exception that gets thrown when attempting to perfom a <see cref="IReverseCallDispatcher{TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse}.Call"/> after the client has closed the connection.
+    /// </summary>
+    public class CannotPerformCallOnCompletedReverseCallConnection : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CannotPerformCallOnCompletedReverseCallConnection"/> class.
+        /// </summary>
+        public CannotPerformCallOnCompletedReverseCallConnection()
+            : base("Cannot perform calls using a ReverseCallDispatcher after the client has closed the connection.")
+        {
+        }
+    }
+}

--- a/Source/Services/IReverseCallDispatcher.cs
+++ b/Source/Services/IReverseCallDispatcher.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Google.Protobuf;
 
@@ -9,23 +10,54 @@ namespace Dolittle.Services
     /// <summary>
     /// Represents a dispatcher that is capable tracking calls from server to client.
     /// </summary>
-    /// <typeparam name="TResponse">Type of <see cref="IMessage"/> for the responses from the client.</typeparam>
-    /// <typeparam name="TRequest">Type of <see cref="IMessage"/> for the requests to the client.</typeparam>
-    public interface IReverseCallDispatcher<TResponse, TRequest>
-        where TResponse : IMessage
-        where TRequest : IMessage
+    /// <typeparam name="TClientMessage">Type of the <see cref="IMessage">messages</see> that is sent from the client to the server.</typeparam>
+    /// <typeparam name="TServerMessage">Type of the <see cref="IMessage">messages</see> that is sent from the server to the client.</typeparam>
+    /// <typeparam name="TConnectArguments">Type of the arguments that are sent along with the initial Connect call.</typeparam>
+    /// <typeparam name="TConnectResponse">Type of the response that is recieved after the initial Connect call.</typeparam>
+    /// <typeparam name="TRequest">Type of the requests sent from the server to the client using <see cref="IReverseCallDispatcher{TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse}.Call"/>.</typeparam>
+    /// <typeparam name="TResponse">Type of the responses recieved from the client using <see cref="IReverseCallDispatcher{TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse}.Call"/>.</typeparam>
+    public interface IReverseCallDispatcher<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse>
+        where TClientMessage : IMessage, new()
+        where TServerMessage : IMessage, new()
+        where TConnectArguments : class
+        where TConnectResponse : class
+        where TRequest : class
+        where TResponse : class
     {
+        /// <summary>
+        /// Gets the <typeparamref name="TConnectArguments"/> recieved from the initial Connect call from the client.
+        /// </summary>
+        TConnectArguments Arguments { get; }
+
+        /// <summary>
+        /// Waits for the initial Connect call arguments from the client.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
+        /// <returns>A <see cref="Task"/> that, when resolved, returns whether arguments was received from the client.</returns>
+        Task<bool> ReceiveArguments(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Accepts the incoming connection from the client. This sends the <typeparamref name="TConnectResponse"/> back to the client, and starts handling of calls.
+        /// </summary>
+        /// <param name="response">The <typeparamref name="TConnectResponse"/> to send to the client.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation of handling of calls.</returns>
+        Task Accept(TConnectResponse response, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Rejects the incoming connection from the client. This sends the <typeparamref name="TConnectResponse"/> back to the client, and closes the connection.
+        /// </summary>
+        /// <param name="response">The <typeparamref name="TConnectResponse"/> to send to the client.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation of closing the connection.</returns>
+        Task Reject(TConnectResponse response, CancellationToken cancellationToken);
+
         /// <summary>
         /// Dispatch a call to the client.
         /// </summary>
-        /// <param name="request">Request <see cref="IMessage"/>.</param>
-        /// <returns>A <see cref="Task"/> that, when resolved, returns the response.</returns>
-        Task<TResponse> Call(TRequest request);
-
-        /// <summary>
-        /// Waits for the <see cref="IReverseCallDispatcher{TResponse, TRequest}" /> to finish dispatching calls.
-        /// </summary>
-        /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
-        Task WaitTillCompleted();
+        /// <param name="request">The <typeparamref name="TRequest"/> to send to the client.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
+        /// <returns>A <see cref="Task"/> that, when resolved, returns the <typeparamref name="TResponse"/> from the client.</returns>
+        Task<TResponse> Call(TRequest request, CancellationToken cancellationToken);
     }
 }

--- a/Source/Services/IReverseCallDispatchers.cs
+++ b/Source/Services/IReverseCallDispatchers.cs
@@ -1,13 +1,10 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-extern alias contracts;
-
 using System;
-using System.Linq.Expressions;
+using Dolittle.Services.Contracts;
 using Google.Protobuf;
 using Grpc.Core;
-using grpc = contracts::Dolittle.Services.Contracts;
 
 namespace Dolittle.Services
 {
@@ -17,23 +14,41 @@ namespace Dolittle.Services
     public interface IReverseCallDispatchers
     {
         /// <summary>
-        /// Get a <see cref="IReverseCallDispatcher{TResponse, TRequest}"/> for specific request and response streams.
+        /// Get a <see cref="IReverseCallDispatcher{TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse}"/> for specific request and response streams.
         /// </summary>
-        /// <param name="responseStream">The <see cref="IAsyncStreamReader{T}"/> for responses coming from the client.</param>
-        /// <param name="requestStream">The <see cref="IServerStreamWriter{T}"/> for requests going to the client.</param>
-        /// <param name="context">Original <see cref="ServerCallContext"/>.</param>
-        /// <param name="responseContextProperty">An <see cref="Expression{T}"/> for describing what property on response message that will hold the <see cref="grpc.ReverseCallResponseContext" />.</param>
-        /// <param name="requestContextProperty">An <see cref="Expression{T}"/> for describing what property on request message that will hold the <see cref="grpc.ReverseCallRequestContext" />.</param>
-        /// <typeparam name="TResponse">Type of <see cref="IMessage"/> for the responses from the client.</typeparam>
-        /// <typeparam name="TRequest">Type of <see cref="IMessage"/> for the requests to the client.</typeparam>
-        /// <returns>A <see cref="IReverseCallDispatcher{TResponse, TRequest}"/>.</returns>
-        IReverseCallDispatcher<TResponse, TRequest> GetDispatcherFor<TResponse, TRequest>(
-            IAsyncStreamReader<TResponse> responseStream,
-            IServerStreamWriter<TRequest> requestStream,
-            ServerCallContext context,
-            Expression<Func<TResponse, grpc.ReverseCallResponseContext>> responseContextProperty,
-            Expression<Func<TRequest, grpc.ReverseCallRequestContext>> requestContextProperty)
-            where TResponse : IMessage
-            where TRequest : IMessage;
+        /// <param name="clientStream">The <see cref="IAsyncStreamReader{TClientMessage}"/> to read client messages from.</param>
+        /// <param name="serverStream">The <see cref="IServerStreamWriter{TServerMessage}"/> to write server messages to.</param>
+        /// <param name="context">The connection <see cref="ServerCallContext">context</see>.</param>
+        /// <param name="getConnectArguments">A delegate to get the <typeparamref name="TConnectArguments"/> from a <typeparamref name="TClientMessage"/>.</param>
+        /// <param name="setConnectResponse">A delegate to set the <typeparamref name="TConnectResponse"/> on a <typeparamref name="TServerMessage"/>.</param>
+        /// <param name="setMessageRequest">A delegate to set the <typeparamref name="TRequest"/> on a <typeparamref name="TServerMessage"/>.</param>
+        /// <param name="getMessageResponse">A delegate to get the <typeparamref name="TResponse"/> from a <typeparamref name="TClientMessage"/>.</param>
+        /// <param name="getArgumentsContext">A delegate to get the <see cref="ReverseCallArgumentsContext"/> from a <typeparamref name="TConnectArguments"/>.</param>
+        /// <param name="setRequestContext">A delegate to set the <see cref="ReverseCallRequestContext"/> on a <typeparamref name="TRequest"/>.</param>
+        /// <param name="getResponseContex">A delegate to get the <see cref="ReverseCallResponseContext"/> from a <typeparamref name="TResponse"/>.</param>
+        /// <typeparam name="TClientMessage">Type of the <see cref="IMessage">messages</see> that is sent from the client to the server.</typeparam>
+        /// <typeparam name="TServerMessage">Type of the <see cref="IMessage">messages</see> that is sent from the server to the client.</typeparam>
+        /// <typeparam name="TConnectArguments">Type of the arguments that are sent along with the initial Connect call.</typeparam>
+        /// <typeparam name="TConnectResponse">Type of the response that is recieved after the initial Connect call.</typeparam>
+        /// <typeparam name="TRequest">Type of the requests sent from the server to the client using <see cref="IReverseCallDispatcher{TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse}.Call"/>.</typeparam>
+        /// <typeparam name="TResponse">Type of the responses recieved from the client using <see cref="IReverseCallDispatcher{TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse}.Call"/>.</typeparam>
+        /// <returns>A <see cref="IReverseCallDispatcher{TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse}"/>.</returns>
+        IReverseCallDispatcher<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse> GetDispatcherFor<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse>(
+                IAsyncStreamReader<TClientMessage> clientStream,
+                IServerStreamWriter<TServerMessage> serverStream,
+                ServerCallContext context,
+                Func<TClientMessage, TConnectArguments> getConnectArguments,
+                Action<TServerMessage, TConnectResponse> setConnectResponse,
+                Action<TServerMessage, TRequest> setMessageRequest,
+                Func<TClientMessage, TResponse> getMessageResponse,
+                Func<TConnectArguments, ReverseCallArgumentsContext> getArgumentsContext,
+                Action<TRequest, ReverseCallRequestContext> setRequestContext,
+                Func<TResponse, ReverseCallResponseContext> getResponseContex)
+            where TClientMessage : IMessage, new()
+            where TServerMessage : IMessage, new()
+            where TConnectArguments : class
+            where TConnectResponse : class
+            where TRequest : class
+            where TResponse : class;
     }
 }

--- a/Source/Services/ReverseCallDispatcher.cs
+++ b/Source/Services/ReverseCallDispatcher.cs
@@ -1,153 +1,248 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-extern alias contracts;
-
 using System;
 using System.Collections.Concurrent;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
+using Dolittle.Execution;
 using Dolittle.Logging;
 using Dolittle.Protobuf;
-using Dolittle.Reflection;
+using Dolittle.Services.Contracts;
 using Google.Protobuf;
 using Grpc.Core;
-using grpc = contracts::Dolittle.Services.Contracts;
 
 namespace Dolittle.Services
 {
     /// <summary>
-    /// Represents an implementation of <see cref="IReverseCallDispatcher{TResponse, TRequest}"/>.
+    /// Represents an implementation of <see cref="IReverseCallDispatcher{TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse}"/>.
     /// </summary>
-    /// <typeparam name="TResponse">Type of <see cref="IMessage"/> for the responses from the client.</typeparam>
-    /// <typeparam name="TRequest">Type of <see cref="IMessage"/> for the requests to the client.</typeparam>
-    public class ReverseCallDispatcher<TResponse, TRequest> : IReverseCallDispatcher<TResponse, TRequest>
-        where TResponse : IMessage
-        where TRequest : IMessage
+    /// <typeparam name="TClientMessage">Type of the <see cref="IMessage">messages</see> that is sent from the client to the server.</typeparam>
+    /// <typeparam name="TServerMessage">Type of the <see cref="IMessage">messages</see> that is sent from the server to the client.</typeparam>
+    /// <typeparam name="TConnectArguments">Type of the arguments that are sent along with the initial Connect call.</typeparam>
+    /// <typeparam name="TConnectResponse">Type of the response that is recieved after the initial Connect call.</typeparam>
+    /// <typeparam name="TRequest">Type of the requests sent from the server to the client using <see cref="IReverseCallDispatcher{TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse}.Call"/>.</typeparam>
+    /// <typeparam name="TResponse">Type of the responses recieved from the client using <see cref="IReverseCallDispatcher{TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse}.Call"/>.</typeparam>
+    public class ReverseCallDispatcher<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse>
+        : IDisposable, IReverseCallDispatcher<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse>
+        where TClientMessage : IMessage, new()
+        where TServerMessage : IMessage, new()
+        where TConnectArguments : class
+        where TConnectResponse : class
+        where TRequest : class
+        where TResponse : class
     {
-        readonly object _lockObject = new object();
-
+        readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1);
         readonly ConcurrentDictionary<ReverseCallId, TaskCompletionSource<TResponse>> _calls = new ConcurrentDictionary<ReverseCallId, TaskCompletionSource<TResponse>>();
-        readonly IAsyncStreamReader<TResponse> _responseStream;
-        readonly IServerStreamWriter<TRequest> _requestStream;
+        readonly IAsyncStreamReader<TClientMessage> _clientStream;
+        readonly IServerStreamWriter<TServerMessage> _serverStream;
         readonly ServerCallContext _context;
+        readonly Func<TClientMessage, TConnectArguments> _getConnectArguments;
+        readonly Action<TServerMessage, TConnectResponse> _setConnectResponse;
+        readonly Action<TServerMessage, TRequest> _setMessageRequest;
+        readonly Func<TClientMessage, TResponse> _getMessageResponse;
+        readonly Func<TConnectArguments, ReverseCallArgumentsContext> _getArgumentsContext;
+        readonly Action<TRequest, ReverseCallRequestContext> _setRequestContext;
+        readonly Func<TResponse, ReverseCallResponseContext> _getResponseContex;
+        readonly IExecutionContextManager _executionContextManager;
         readonly ILogger _logger;
-        readonly Func<TResponse, grpc.ReverseCallResponseContext> _getResponseContext;
-        readonly Func<TRequest, grpc.ReverseCallRequestContext> _getRequestContext;
-        readonly PropertyInfo _requestContextProperty;
-        readonly TaskCompletionSource<bool> _dispatcherCompletionSource;
+        bool _completed;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ReverseCallDispatcher{TResponse, TRequest}"/> class.
+        /// Initializes a new instance of the <see cref="ReverseCallDispatcher{TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse}"/> class.
         /// </summary>
-        /// <param name="responseStream">The <see cref="IAsyncStreamReader{T}"/> for responses coming from the client.</param>
-        /// <param name="requestStream">The <see cref="IServerStreamWriter{T}"/> for requests going to the client.</param>
-        /// <param name="context">Original <see cref="ServerCallContext"/>.</param>
-        /// <param name="responseContextProperty">An <see cref="Expression{T}"/> for describing what property on response message that will hold the <see cref="grpc.ReverseCallResponseContext" />.</param>
-        /// <param name="requestContextProperty">An <see cref="Expression{T}"/> for describing what property on request message that will hold the <see cref="grpc.ReverseCallRequestContext" />.</param>
-        /// <param name="logger"><see cref="ILogger"/> for logging.</param>
+        /// <param name="clientStream">The <see cref="IAsyncStreamReader{TClientMessage}"/> to read client messages from.</param>
+        /// <param name="serverStream">The <see cref="IServerStreamWriter{TServerMessage}"/> to write server messages to.</param>
+        /// <param name="context">The connection <see cref="ServerCallContext">context</see>.</param>
+        /// <param name="getConnectArguments">A delegate to get the <typeparamref name="TConnectArguments"/> from a <typeparamref name="TClientMessage"/>.</param>
+        /// <param name="setConnectResponse">A delegate to set the <typeparamref name="TConnectResponse"/> on a <typeparamref name="TServerMessage"/>.</param>
+        /// <param name="setMessageRequest">A delegate to set the <typeparamref name="TRequest"/> on a <typeparamref name="TServerMessage"/>.</param>
+        /// <param name="getMessageResponse">A delegate to get the <typeparamref name="TResponse"/> from a <typeparamref name="TClientMessage"/>.</param>
+        /// <param name="getArgumentsContext">A delegate to get the <see cref="ReverseCallArgumentsContext"/> from a <typeparamref name="TConnectArguments"/>.</param>
+        /// <param name="setRequestContext">A delegate to set the <see cref="ReverseCallRequestContext"/> on a <typeparamref name="TRequest"/>.</param>
+        /// <param name="getResponseContex">A delegate to get the <see cref="ReverseCallResponseContext"/> from a <typeparamref name="TResponse"/>.</param>
+        /// <param name="executionContextManager">The <see cref="IExecutionContextManager"/> to use.</param>
+        /// <param name="logger">The <see cref="ILogger"/> to use.</param>
         public ReverseCallDispatcher(
-            IAsyncStreamReader<TResponse> responseStream,
-            IServerStreamWriter<TRequest> requestStream,
-            ServerCallContext context,
-            Expression<Func<TResponse, grpc.ReverseCallResponseContext>> responseContextProperty,
-            Expression<Func<TRequest, grpc.ReverseCallRequestContext>> requestContextProperty,
-            ILogger logger)
+                IAsyncStreamReader<TClientMessage> clientStream,
+                IServerStreamWriter<TServerMessage> serverStream,
+                ServerCallContext context,
+                Func<TClientMessage, TConnectArguments> getConnectArguments,
+                Action<TServerMessage, TConnectResponse> setConnectResponse,
+                Action<TServerMessage, TRequest> setMessageRequest,
+                Func<TClientMessage, TResponse> getMessageResponse,
+                Func<TConnectArguments, ReverseCallArgumentsContext> getArgumentsContext,
+                Action<TRequest, ReverseCallRequestContext> setRequestContext,
+                Func<TResponse, ReverseCallResponseContext> getResponseContex,
+                IExecutionContextManager executionContextManager,
+                ILogger logger)
         {
-            _responseStream = responseStream;
-            _requestStream = requestStream;
+            _clientStream = clientStream;
+            _serverStream = serverStream;
             _context = context;
+            _getConnectArguments = getConnectArguments;
+            _setConnectResponse = setConnectResponse;
+            _setMessageRequest = setMessageRequest;
+            _getMessageResponse = getMessageResponse;
+            _getArgumentsContext = getArgumentsContext;
+            _setRequestContext = setRequestContext;
+            _getResponseContex = getResponseContex;
+            _executionContextManager = executionContextManager;
             _logger = logger;
-            _getResponseContext = responseContextProperty.Compile();
-            _getRequestContext = requestContextProperty.Compile();
-            _requestContextProperty = requestContextProperty.GetPropertyInfo();
-
-            _dispatcherCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-            Task.Run(HandleResponse);
         }
 
         /// <inheritdoc/>
-        public Task<TResponse> Call(TRequest request)
-        {
-            lock (_lockObject)
-            {
-                var callId = new ReverseCallId { Value = Guid.NewGuid() };
-                var requestContext = _getRequestContext(request);
-                requestContext.CallId = callId.ToProtobuf();
-                _requestContextProperty.SetValue(request, requestContext);
-
-                if (!_calls.TryGetValue(callId, out var completionSource))
-                {
-                    completionSource = new TaskCompletionSource<TResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
-                    completionSource.Task.ContinueWith(_ => _calls.TryRemove(callId, out var _), TaskScheduler.Current);
-
-                    _calls[callId] = completionSource;
-                    _logger.Trace("Dispatching reverse call with Call Id = '{callId}' Request = {request}", callId, request);
-                    _requestStream.WriteAsync(request).GetAwaiter().GetResult();
-                }
-                else
-                {
-                    _logger.Debug("Reverse call with Call Id = '{callId}' is already dispatched", callId);
-                }
-
-                return completionSource.Task;
-            }
-        }
+        public TConnectArguments Arguments { get; private set; }
 
         /// <inheritdoc/>
-        public Task WaitTillCompleted() => _dispatcherCompletionSource.Task;
-
-        async Task HandleResponse()
+        public async Task<bool> ReceiveArguments(CancellationToken cancellationToken)
         {
-            try
+            if (await _clientStream.MoveNext(cancellationToken).ConfigureAwait(false))
             {
-                while (await _responseStream.MoveNext(_context.CancellationToken).ConfigureAwait(false))
+                var arguments = _getConnectArguments(_clientStream.Current);
+                if (arguments != null)
                 {
-                    var response = _responseStream.Current;
-                    var responseContext = _getResponseContext(response);
-                    var callId = responseContext.CallId.To<ReverseCallId>();
-                    if (!_calls.TryGetValue(callId, out var completionSource))
+                    var callContext = _getArgumentsContext(arguments);
+                    if (callContext?.ExecutionContext != null)
                     {
-                        _logger.Warning("Received response with an unmapped reverse Call Id = '{callId}'. Discarding response", callId);
+                        _executionContextManager.CurrentFor(callContext.ExecutionContext.ToExecutionContext());
+                        Arguments = arguments;
+                        return true;
                     }
                     else
                     {
-                        completionSource.SetResult(response);
+                        _logger.Warning("Reieved arguments, but call execution context was not set.");
                     }
                 }
+                else
+                {
+                    _logger.Warning("Recieved initial message from client, but arguments was not set.");
+                }
+            }
 
-                _dispatcherCompletionSource.TrySetResult(true);
-                CancelRemainingCalls();
+            return false;
+        }
+
+        /// <inheritdoc/>
+        public async Task Accept(TConnectResponse response, CancellationToken cancellationToken)
+        {
+            var message = new TServerMessage();
+            _setConnectResponse(message, response);
+            await _serverStream.WriteAsync(message).ConfigureAwait(false);
+            await HandleClientMessages(cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public Task Reject(TConnectResponse response, CancellationToken cancellationToken)
+        {
+            var message = new TServerMessage();
+            _setConnectResponse(message, response);
+            return _serverStream.WriteAsync(message);
+        }
+
+        /// <inheritdoc/>
+        public async Task<TResponse> Call(TRequest request, CancellationToken cancellationToken)
+        {
+            if (_completed)
+            {
+                throw new CannotPerformCallOnCompletedReverseCallConnection();
+            }
+
+            var completionSource = new TaskCompletionSource<TResponse>();
+            var callId = ReverseCallId.New();
+            while (!_calls.TryAdd(callId, completionSource))
+            {
+                callId = ReverseCallId.New();
+            }
+
+            try
+            {
+                await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+                try
+                {
+                    var callContext = new ReverseCallRequestContext
+                    {
+                        CallId = callId.ToProtobuf(),
+                        ExecutionContext = _executionContextManager.Current.ToProtobuf(),
+                    };
+                    _setRequestContext(request, callContext);
+
+                    var message = new TServerMessage();
+                    _setMessageRequest(message, request);
+
+                    await _serverStream.WriteAsync(message).ConfigureAwait(false);
+                }
+                finally
+                {
+                    _semaphore.Release();
+                }
+
+                return await completionSource.Task.ConfigureAwait(false);
+            }
+            catch
+            {
+                _calls.TryRemove(callId, out _);
+                throw;
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            _semaphore.Dispose();
+        }
+
+        async Task HandleClientMessages(CancellationToken cancellationToken)
+        {
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested && await _clientStream.MoveNext(cancellationToken).ConfigureAwait(false))
+                {
+                    var response = _getMessageResponse(_clientStream.Current);
+                    if (response != null)
+                    {
+                        var callContext = _getResponseContex(response);
+                        if (callContext?.CallId != null)
+                        {
+                            var callId = callContext.CallId.To<ReverseCallId>();
+                            if (_calls.TryRemove(callId, out var completionSource))
+                            {
+                                completionSource.SetResult(response);
+                            }
+                            else
+                            {
+                                _logger.Warning("Could not find the call id from the recieved response from the client. The message will be ignored.");
+                            }
+                        }
+                        else
+                        {
+                            _logger.Warning("Recieved response from reverse call client, but the call context was not set.");
+                        }
+                    }
+                    else
+                    {
+                        _logger.Warning("Recieved message from reverse call client, but it did not conatin a response.");
+                    }
+                }
             }
             catch (Exception ex)
             {
-                _dispatcherCompletionSource.TrySetException(ex);
-                CancelRemainingCalls(ex);
+                _logger.Error(ex, "Exception during handling of client messages");
             }
-        }
-
-        void CancelRemainingCalls()
-        {
-            _logger.Debug("Cancelling remaining uncompleted reverse calls");
-
-            foreach ((var callId, var completionSource) in _calls.Where(_ => !_.Value.Task.IsCompleted).ToList())
+            finally
             {
-                _logger.Trace("Cancelling uncompleted call with reverse call id '{callId}'", callId);
-                completionSource.TrySetCanceled();
-            }
-        }
-
-        void CancelRemainingCalls(Exception ex)
-        {
-            _logger.Warning(ex, "Reading from response stream failed. Cancelling remaining uncompleted reverse calls");
-
-            foreach ((var callId, var completionSource) in _calls.Where(_ => !_.Value.Task.IsCompleted).ToList())
-            {
-                _logger.Trace("Cancelling uncompleted call with reverse call id '{callId}'", callId);
-                completionSource.TrySetException(ex);
+                _completed = true;
+                foreach ((_, var completionSource) in _calls)
+                {
+                    try
+                    {
+                        completionSource.SetCanceled();
+                    }
+                    catch
+                    {
+                    }
+                }
             }
         }
     }

--- a/Source/Services/ReverseCallDispatchers.cs
+++ b/Source/Services/ReverseCallDispatchers.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-extern alias contracts;
-
 using System;
-using System.Linq.Expressions;
+using Dolittle.Execution;
 using Dolittle.Logging;
+using Dolittle.Services.Contracts;
 using Google.Protobuf;
 using Grpc.Core;
-using grpc = contracts::Dolittle.Services.Contracts;
 
 namespace Dolittle.Services
 {
@@ -17,34 +15,50 @@ namespace Dolittle.Services
     /// </summary>
     public class ReverseCallDispatchers : IReverseCallDispatchers
     {
-        readonly ILogger _logger;
+        readonly IExecutionContextManager _executionContextManager;
+        readonly ILoggerManager _loggerManager;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ReverseCallDispatchers"/> class.
         /// </summary>
-        /// <param name="logger"><see cref="ILogger"/> for logging.</param>
-        public ReverseCallDispatchers(ILogger logger)
+        /// <param name="executionContextManager">The <see cref="IExecutionContextManager"/> to use.</param>
+        /// <param name="loggerManager">The <see cref="ILoggerManager"/> to use for creating instances of <see cref="ILogger"/>.</param>
+        public ReverseCallDispatchers(IExecutionContextManager executionContextManager, ILoggerManager loggerManager)
         {
-            _logger = logger;
+            _executionContextManager = executionContextManager;
+            _loggerManager = loggerManager;
         }
 
         /// <inheritdoc/>
-        public IReverseCallDispatcher<TResponse, TRequest> GetDispatcherFor<TResponse, TRequest>(
-            IAsyncStreamReader<TResponse> responseStream,
-            IServerStreamWriter<TRequest> requestStream,
+        public IReverseCallDispatcher<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse> GetDispatcherFor<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse>(
+            IAsyncStreamReader<TClientMessage> clientStream,
+            IServerStreamWriter<TServerMessage> serverStream,
             ServerCallContext context,
-            Expression<Func<TResponse, grpc.ReverseCallResponseContext>> responseContextProperty,
-            Expression<Func<TRequest, grpc.ReverseCallRequestContext>> requestContextProperty)
-            where TResponse : IMessage
-            where TRequest : IMessage
-        {
-            return new ReverseCallDispatcher<TResponse, TRequest>(
-                responseStream,
-                requestStream,
+            Func<TClientMessage, TConnectArguments> getConnectArguments,
+            Action<TServerMessage, TConnectResponse> setConnectResponse,
+            Action<TServerMessage, TRequest> setMessageRequest,
+            Func<TClientMessage, TResponse> getMessageResponse,
+            Func<TConnectArguments, ReverseCallArgumentsContext> getArgumentsContext,
+            Action<TRequest, ReverseCallRequestContext> setRequestContext,
+            Func<TResponse, ReverseCallResponseContext> getResponseContex)
+            where TClientMessage : IMessage, new()
+            where TServerMessage : IMessage, new()
+            where TConnectArguments : class
+            where TConnectResponse : class
+            where TRequest : class
+            where TResponse : class
+            => new ReverseCallDispatcher<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse>(
+                clientStream,
+                serverStream,
                 context,
-                responseContextProperty,
-                requestContextProperty,
-                _logger);
-        }
+                getConnectArguments,
+                setConnectResponse,
+                setMessageRequest,
+                getMessageResponse,
+                getArgumentsContext,
+                setRequestContext,
+                getResponseContex,
+                _executionContextManager,
+                _loggerManager.CreateLogger<ReverseCallDispatcher<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse>>());
     }
 }

--- a/Source/Services/ReverseCallId.cs
+++ b/Source/Services/ReverseCallId.cs
@@ -16,5 +16,11 @@ namespace Dolittle.Services
         /// </summary>
         /// <param name="id">The id.</param>
         public static implicit operator ReverseCallId(Guid id) => new ReverseCallId { Value = id };
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="ReverseCallId"/>.
+        /// </summary>
+        /// <returns>A new <see cref="ReverseCallId"/>.</returns>
+        public static ReverseCallId New() => new ReverseCallId { Value = Guid.NewGuid() };
     }
 }

--- a/Source/Services/Services.csproj
+++ b/Source/Services/Services.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" Alias="contracts"/>
+    <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
     <PackageReference Include="Google.Protobuf" Version="3.11.2" />
     <PackageReference Include="Grpc" Version="2.26.0" />
   </ItemGroup>


### PR DESCRIPTION
It is not tested, and I have not done any effort on checking specs.

It is probably worth it to have a second pass on places where exceptions can get thrown as well.

The idea of usage is that in a gRPC server implementation, in a server call handle method you would:

1. Get a IReverseCallDispatcher from the IReverseCallDispathers, by giving it the two streams, and a bunch of delegates to get and set the correct properties on the messages.
2. Await the receiving of the Connect arguments from the client by calling ReceiveArguments(). If it returns true, you got arguments in the Arguments property, if it returns false something wrong happen and don't do anything more. Returning from the handler will close the connection.
3. Check the arguments and perform any validation, and then choose to either Accept or Reject the connection, in both cases with a response to the client.
   * Rejecting the connection just writes the response, and does nothing more, so the connection is closed.
   * Accepting the connection writes the response, then starts an infinite loop reading responses back from the client.
4. After that, the IReverseCallDispatcher can be passed to other components, which can then use Call with a request, and await the task to recieve the correct response from the client.

A thought that occured to me now, is that it is important to send any requests to the client before the connect response is sent. So if the call dispatcher is passed to other objects before it is accepted, we might need to initialise the semaphore with a (0), and release it again in Accept and Reject.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1172101503333801)
