### PR TITLE
Fix ILogger resolution for ACTNARs

### DIFF
--- a/Source/DependencyInversion.Autofac/LoggerModule.cs
+++ b/Source/DependencyInversion.Autofac/LoggerModule.cs
@@ -14,13 +14,20 @@ namespace Dolittle.DependencyInversion.Autofac
     /// </summary>
     public class LoggerModule : Module
     {
-        /// <inheritdoc/>
-        protected override void AttachToComponentRegistration(IComponentRegistryBuilder componentRegistry, IComponentRegistration registration)
+        /// <summary>
+        /// Attaches to the <see cref="IComponentRegistration.Preparing"/> event to provide the correctly typed <see cref="ILogger{T}"/> of the type of component being constructed, when an untyped <see cref="ILogger"/> is used as a dependency.
+        /// </summary>
+        /// <param name="registration">The <see cref="IComponentRegistration"/> to attach to.</param>
+        internal static void ResolveUntypedLoggersFor(IComponentRegistration registration)
         {
             registration.Preparing += OnComponentPreparing;
         }
 
-        void OnComponentPreparing(object sender, PreparingEventArgs e)
+        /// <inheritdoc/>
+        protected override void AttachToComponentRegistration(IComponentRegistryBuilder componentRegistry, IComponentRegistration registration)
+            => ResolveUntypedLoggersFor(registration);
+
+        static void OnComponentPreparing(object sender, PreparingEventArgs e)
         {
             e.Parameters = e.Parameters.Append(
                 new ResolvedParameter(

--- a/Source/DependencyInversion.Autofac/SelfBindingRegistrationSource.cs
+++ b/Source/DependencyInversion.Autofac/SelfBindingRegistrationSource.cs
@@ -97,7 +97,9 @@ namespace Dolittle.DependencyInversion.Autofac
 
             var builder = RegistrationBuilder.ForType(ts.ServiceType);
             RegistrationConfiguration?.Invoke(builder);
-            return new[] { builder.CreateRegistration() };
+            var registration = builder.CreateRegistration();
+            LoggerModule.ResolveUntypedLoggersFor(registration);
+            return new[] { registration };
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes almost all "UnknownLogMessageSource" warnings printed. We ask the container to construct concrete types in many places, and since these registrations are provided on-the-fly, they are not sent through the normal LoggerModule. This commit adds the same resolution step for those components that are registered with the SelfBindingRegistrationSource, which removes the problem for those registrations.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1174360108882766)
