### PR TITLE
Fix trace logger crashes

### DIFF
--- a/Source/Execution/ExecutionContextManager.cs
+++ b/Source/Execution/ExecutionContextManager.cs
@@ -147,7 +147,7 @@ namespace Dolittle.Execution
             int lineNumber,
             string member)
         {
-            _logger.Trace("Setting execution context ({context}) - from: ({filePath}, {lineNumber}, {member}) ", filePath, lineNumber, member);
+            _logger.Trace("Setting execution context ({context}) - from: ({filePath}, {lineNumber}, {member}) ", context, filePath, lineNumber, member);
             Current = context;
             return context;
         }

--- a/Source/Logging/Booting/BootLogMessageWriterCreator.cs
+++ b/Source/Logging/Booting/BootLogMessageWriterCreator.cs
@@ -47,8 +47,14 @@ namespace Dolittle.Logging.Booting
 
                 for (var i = 0; i < writers.Length; ++i)
                 {
-                    if (message.Exception == null) writers[i].Write(message.LogLevel, message.Message, message.Arguments);
-                    else writers[i].Write(message.LogLevel, message.Exception, message.Message, message.Arguments);
+                    try
+                    {
+                        if (message.Exception == null) writers[i].Write(message.LogLevel, message.Message, message.Arguments);
+                        else writers[i].Write(message.LogLevel, message.Exception, message.Message, message.Arguments);
+                    }
+                    catch
+                    {
+                    }
                 }
             }
         }


### PR DESCRIPTION
A combination of bugs caused applications to crash if they used our logging and enabled `trace` level logging. These two commits fixes the cause of the exception - but also catches similar exceptions in the future.

This will hide errors we do in log messages, but we need to figure out another way to deal with those later.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1176733419116654)
